### PR TITLE
Add RewindInstance RPC definition

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -258,7 +258,7 @@ message GetInstanceResponse {
 
 message RewindInstanceRequest {
     string instanceId = 1;
-    string reason = 2;
+    google.protobuf.StringValue reason = 2;
 }
 
 message RewindInstanceResponse {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -256,6 +256,15 @@ message GetInstanceResponse {
     OrchestrationState orchestrationState = 2;
 }
 
+message RewindInstanceRequest {
+    string instanceId = 1;
+    string reason = 2;
+}
+
+message RewindInstanceResponse {
+    // Empty for now. Using explicit type incase we want to add content later.
+}
+
 message OrchestrationState {
     string instanceId = 1;
     string name = 2;
@@ -351,6 +360,9 @@ service TaskHubSidecarService {
 
     // Gets the status of an existing orchestration instance.
     rpc GetInstance(GetInstanceRequest) returns (GetInstanceResponse);
+
+    // Rewinds an orchestration instance to last known good state and replays from there.
+    rpc RewindInstance(RewindInstanceRequest) returns (RewindInstanceResponse);
 
     // Waits for an orchestration instance to reach a running or completion state.
     rpc WaitForInstanceStart(GetInstanceRequest) returns (GetInstanceResponse);


### PR DESCRIPTION
This will let implementations (optionally) implement Rewind functionality. DTFx Core does not support rewind natively yet. This will let Durable Functions isolated support this functionality right away without waiting on official DTFx Core support.