### PR TITLE
Support for cascade terminate

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -75,6 +75,7 @@ message ExecutionCompletedEvent {
 
 message ExecutionTerminatedEvent {
     google.protobuf.StringValue input = 1;
+    bool recurse = 2;
 }
 
 message TaskScheduledEvent {
@@ -217,6 +218,12 @@ message CompleteOrchestrationAction {
     TaskFailureDetails failureDetails = 6;
 }
 
+message TerminateOrchestrationAction {
+    string instanceId = 1;
+    google.protobuf.StringValue reason = 2;
+    bool recurse = 3;
+}
+
 message OrchestratorAction {
     int32 id = 1;
     oneof orchestratorActionType {
@@ -225,6 +232,7 @@ message OrchestratorAction {
         CreateTimerAction createTimer = 4;
         SendEventAction sendEvent = 5;
         CompleteOrchestrationAction completeOrchestration = 6;
+        TerminateOrchestrationAction terminateOrchestration = 7;
     }
 }
 
@@ -299,6 +307,7 @@ message RaiseEventResponse {
 message TerminateRequest {
     string instanceId = 1;
     google.protobuf.StringValue output = 2;
+    bool recursive = 3;
 }
 
 message TerminateResponse {


### PR DESCRIPTION
This change is to support recursive/cascading orchestration termination. This was developed as part of https://github.com/microsoft/durabletask-go/pull/24. To summarize:

- A new property on `TerminateRequest` indicating whether a terminate operation should be recursive
- A corresponding property on `ExecutionTerminatedEvent`, matching the above
- A new `TerminateOrchestrationAction` action, which can be returned by an SDK

Note that these changes also make it possible for an orchestration to manually terminate another orchestration, though we don't currently have any plans to expose this in any SDK.