### PR TITLE
small fixes to entity support

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -434,7 +434,7 @@ message EntityMetadata
 {
     string instanceId = 1;
     google.protobuf.Timestamp lastModifiedTime = 2;
-    string serializedState = 3;
+    google.protobuf.StringValue serializedState = 3;
 }
 
 message CleanEntityStorageRequest
@@ -467,6 +467,7 @@ message EntityBatchResult {
     repeated OperationResult results = 1;
     repeated OperationAction actions = 2;
     google.protobuf.StringValue entityState = 3;
+    TaskFailureDetails failureDetails = 4;
 }
 
 message OperationRequest {


### PR DESCRIPTION
Two minor fixes:

- `serializedState` must allow null because queries can ask for  the state to not be included.
- forgot to serialize/deserialize the `failureDetails` field as part of the `EntityBatchResult` data structure.