### PR TITLE
add entity parameters to orchestrator requests

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -8,6 +8,7 @@ option java_package = "com.microsoft.durabletask.implementation.protobuf";
 option go_package = "/internal/protos";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/empty.proto";
 
@@ -241,6 +242,7 @@ message OrchestratorRequest {
     google.protobuf.StringValue executionId = 2;
     repeated HistoryEvent pastEvents = 3;
     repeated HistoryEvent newEvents = 4;
+    OrchestratorEntityParameters entityParameters = 5;
 }
 
 message OrchestratorResponse {
@@ -451,16 +453,15 @@ message CleanEntityStorageResponse
     int32 orphanedLocksReleased = 3;
 }
 
+message OrchestratorEntityParameters
+{
+    google.protobuf.Duration entityMessageReorderWindow = 1;
+}
+
 message EntityBatchRequest {
     string instanceId = 1;
     google.protobuf.StringValue entityState = 2;
     repeated OperationRequest operations = 3;
-}
-
-message EntityBackendProperties
-{
-    int64 entityMessageReorderWindow = 1;
-    int64 maximumSignalDelayTime = 2;
 }
 
 message EntityBatchResult {


### PR DESCRIPTION
Orchestrators need to know some information about the backend entity capabilities to properly handle entity operations.
This PR allows the backend to convey this information to the front end via some extra content on the orchestrator requests.