### PR TITLE
Update `GenericEvent` to accept null value

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -150,7 +150,7 @@ message EventRaisedEvent {
 }
 
 message GenericEvent {
-    string data = 1;
+    google.protobuf.StringValue data = 1;
 }
 
 message HistoryStateEvent {


### PR DESCRIPTION
`GenericEvent` is currently used in rewind logic to store the rewind reason. Currently, if no reason is provided it will throw null value exception. It should allow the user to rewind their orchestration without providing a reason. 

TODO: validate if it could be a breaking change. 