### PR TITLE
Support orchestration id reuse policies

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -275,7 +275,7 @@ message CreateInstanceOption {
 }
 
 enum CreateOrchestrationAction {
-    THROW = 0;
+    ERROR = 0;
     SKIP = 1;
     TERMINATE = 2;
 }

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -266,10 +266,10 @@ message CreateInstanceRequest {
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
     google.protobuf.Timestamp scheduledStartTimestamp = 5;
-    CreateInstanceOption createInstanceOption = 6;
+    OrchestrationIdReusePolicy orchestrationIdReusePolicy = 6;
 }
 
-message CreateInstanceOption {
+message OrchestrationIdReusePolicy {
     repeated OrchestrationStatus operationStatus = 1;
     CreateOrchestrationAction action = 2;
 }

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -276,7 +276,7 @@ message OrchestrationIdReusePolicy {
 
 enum CreateOrchestrationAction {
     ERROR = 0;
-    SKIP = 1;
+    IGNORE = 1;
     TERMINATE = 2;
 }
 

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -266,6 +266,18 @@ message CreateInstanceRequest {
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
     google.protobuf.Timestamp scheduledStartTimestamp = 5;
+    CreateInstanceOption createInstanceOption = 6;
+}
+
+message CreateInstanceOption {
+    repeated OrchestrationStatus operationStatus = 1;
+    CreateOrchestrationAction action = 2;
+}
+
+enum CreateOrchestrationAction {
+    THROW = 0;
+    SKIP = 1;
+    TERMINATE = 2;
 }
 
 message CreateInstanceResponse {


### PR DESCRIPTION
This PR update grpc proto to allow customers to pass `InstanceExistOption` when creating a new orchestrator. 
More info please refer to https://github.com/microsoft/durabletask-go/issues/42