### PR TITLE
Adding executionStartedTimestamp property to ExecutionStartedEvent message

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -73,6 +73,7 @@ message ExecutionStartedEvent {
     google.protobuf.Timestamp scheduledStartTimestamp = 6;
     TraceContext parentTraceContext = 7;
     google.protobuf.StringValue orchestrationSpanID = 8;
+    google.protobuf.Timestamp executionStartedTimestamp = 9;
 }
 
 message ExecutionCompletedEvent {


### PR DESCRIPTION
This PR adds executionStartedTimestamp property to ExecutionStartedEvent, to capture the execution started timestamp for workflow.

We are adding this property to capture workflowExecutionElapsed time, and this needs workflowExecutionStartedTime to be captured and saved.