### PR TITLE
Backend service RPCs

### DIFF
--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -7,7 +7,7 @@ package durabletask.protos.backend.v1;
 
 option csharp_namespace = "Microsoft.DurableTask.Protobuf";
 option java_package = "com.microsoft.durabletask.implementation.protobuf";
-option go_package = "/internal/protos";
+option go_package = "github.com/microsoft/durabletask-protobuf/internal/protos";
 
 import "orchestrator_service.proto";
 
@@ -20,54 +20,68 @@ import "google/protobuf/empty.proto";
 // The RPCs in this service are used by DTFx backends to manage orchestration state.
 service BackendService {
     // Creates a new orchestration instance.
-    rpc CreateOrchestrationInstance (CreateInstanceRequest) returns (CreateInstanceResponse);
+    rpc CreateInstance (CreateInstanceRequest) returns (CreateInstanceResponse);
 
     // Sends an event to an orchestration instance. This RPC is used for raising external events to orchestrations
     // and for sending orchestration lifecycle events, such as terminate, suspend, resume, etc.
-    rpc AddOrchestrationEvent (AddOrchestrationEventRequest) returns (google.protobuf.Empty);
+    rpc AddEvent (AddEventRequest) returns (AddEventResponse);
 
     // Returns metadata about an orchestration instance.
-    rpc GetOrchestrationMetadata (GetInstanceRequest) returns (GetInstanceResponse);
+    rpc GetInstance (GetInstanceRequest) returns (GetInstanceResponse);
 
     // Waits for an orchestration to reach a terminal state and then returns metadata for that orchestration.
-    rpc WaitForOrchestrationCompletion(GetInstanceRequest) returns (GetInstanceResponse);
+    rpc WaitForInstance (WaitForInstanceRequest) returns (WaitForInstanceResponse);
 
     // Purges the state of one or more orchestration instances.
-    rpc PurgeOrchestrationState (PurgeInstancesRequest) returns (PurgeInstancesResponse);
+    rpc PurgeInstances (PurgeInstancesRequest) returns (PurgeInstancesResponse);
 
     // TODO: Additional operations, such as listing orchestrations
 
     // Starts a server stream for receiving work items
-    rpc GetWorkItems(GetWorkItemsRequest) returns (stream WorkItem);
+    rpc GetWorkItems (GetWorkItemsRequest) returns (stream WorkItem);
 
     // Gets orchestration runtime state (history, etc.) for a given orchestration instance.
     rpc GetOrchestrationRuntimeState (GetOrchestrationRuntimeStateRequest) returns (GetOrchestrationRuntimeStateResponse);
 
     // Completes an outstanding activity work item and adds a new event to the target orchestration's inbox.
-    rpc CompleteActivityWorkItem (CompleteActivityWorkItemRequest) returns (google.protobuf.Empty);
+    rpc CompleteActivityWorkItem (CompleteActivityWorkItemRequest) returns (CompleteActivityWorkItemResponse);
 
     // Abandons an outstanding activity work item. Abandoned work items will be delivered again after some delay.
-    rpc AbandonActivityWorkItem (AbandonActivityWorkItemRequest) returns (google.protobuf.Empty);
+    rpc AbandonActivityWorkItem (AbandonActivityWorkItemRequest) returns (AbandonActivityWorkItemResponse);
 
     // Completes an outstanding orchestrator work item, and adds a new event to the target orchestration's inbox.
-    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (google.protobuf.Empty);
+    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (CompleteOrchestrationWorkItemResponse);
 
     // Abandons an outstanding orchestrator work item. Abandoned work items will be delivered again after some delay.
-    rpc AbandonOrchestrationWorkItem (AbandonOrchestrationWorkItemRequest) returns (google.protobuf.Empty);
-
-    // Fetches metadata about the connected service.
-    rpc Metadata(google.protobuf.Empty) returns (google.protobuf.Empty); // TODO: Payloads
+    rpc AbandonOrchestrationWorkItem (AbandonOrchestrationWorkItemRequest) returns (AbandonOrchestrationWorkItemResponse);
 
     // Sends a health check ping to the backend service.
-    rpc Ping(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc Ping (PingRequest) returns (PingResponse);
 }
 
 // Request payload for adding new orchestration events.
-message AddOrchestrationEventRequest {
+message AddEventRequest {
     // The ID of the orchestration to send an event to.
     OrchestrationInstance instance = 1;
     // The event to send to the orchestration.
     HistoryEvent event = 2;
+}
+
+// Response payload for adding new orchestration events.
+message AddEventResponse {
+    // No fields
+}
+
+// Request payload for waiting for instance completion.
+message WaitForInstanceRequest {
+    string instanceId = 1;
+    bool getInputsAndOutputs = 2;
+}
+
+// Response payload for waiting for instance completion.
+message WaitForInstanceResponse {
+    bool exists = 1;
+    OrchestrationState orchestrationState = 2;
 }
 
 // Request parameters for fetching orchestration runtime state.
@@ -92,10 +106,20 @@ message CompleteActivityWorkItemRequest {
     HistoryEvent responseEvent = 2;
 }
 
+// Response payload for completing an activity work item.
+message CompleteActivityWorkItemResponse {
+    // No fields
+}
+
 // Request payload for abandoning an activity work item.
 message AbandonActivityWorkItemRequest {
     // The completion token that was provided when the work item was fetched.
     string completionToken = 1;
+}
+
+// Response payload for abandoning an activity work item.
+message AbandonActivityWorkItemResponse {
+	// No fields
 }
 
 // Request payload for completing an orchestration work item.
@@ -111,6 +135,11 @@ message CompleteOrchestrationWorkItemRequest {
     repeated OrchestratorMessage newMessages = 8;
 }
 
+// Response payload for completing an orchestration work item.
+message CompleteOrchestrationWorkItemResponse {
+	// No fields
+}
+
 // A message to be delivered to an orchestration by the backend.
 message OrchestratorMessage {
     // The ID of the orchestration instance to receive the message.
@@ -123,4 +152,19 @@ message OrchestratorMessage {
 message AbandonOrchestrationWorkItemRequest {
     // The completion token that was provided when the work item was fetched.
     string completionToken = 1;
+}
+
+// Response payload for abandoning an orchestration work item.
+message AbandonOrchestrationWorkItemResponse {
+	// No fields
+}
+
+// Request payload for ping operations.
+message PingRequest {
+	// No fields
+}
+
+// Response payload for ping operations.
+message PingResponse {
+	// No fields
 }

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -127,7 +127,7 @@ message AbandonActivityWorkItemResponse {
 message CompleteOrchestrationWorkItemRequest {
     // The completion token that was provided when the work item was fetched.
     string completionToken = 1;
-    OrchestrationInstance instance = 2;
+    google.protobuf.StringValue newExecutionId = 2;
     OrchestrationStatus runtimeStatus = 3;
     google.protobuf.StringValue customStatus = 4;
     repeated HistoryEvent newHistory = 5;

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+syntax = "proto3";
+
+package durabletask.protos.backend.v1;
+
+option csharp_namespace = "Microsoft.DurableTask.Protobuf";
+option java_package = "com.microsoft.durabletask.implementation.protobuf";
+option go_package = "/internal/protos";
+
+import "orchestrator_service.proto";
+
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/empty.proto";
+
+// gRPC service used by Durable Task Framework (DTFx) backend implementations.
+// The RPCs in this service are used by DTFx clients to manage orchestrations.
+service ClientBackendService {
+    // Creates a new orchestration instance.
+    rpc CreateOrchestrationInstance (CreateInstanceRequest) returns (CreateInstanceResponse);
+
+    // Sends an event to an orchestration instance. This RPC is used for raising external events to orchestrations
+    // and for sending orchestration lifecycle events, such as terminate, suspend, resume, etc.
+    rpc AddOrchestrationEvent (AddOrchestrationEventRequest) returns (google.protobuf.Empty);
+
+    // Returns metadata about an orchestration instance.
+    rpc GetOrchestrationMetadata (GetInstanceRequest) returns (GetInstanceResponse);
+
+    // Waits for an orchestration to reach a terminal state and then returns metadata for that orchestration.
+    rpc WaitForOrchestrationCompletion(GetInstanceRequest) returns (GetInstanceResponse);
+
+    // Purges the state of one or more orchestration instances.
+    rpc PurgeOrchestrationState (PurgeInstancesRequest) returns (PurgeInstancesResponse);
+
+    // TODO: Additional operations, such as listing orchestrations
+}
+
+// gRPC service used by Durable Task Framework (DTFx) backend implementations.
+// The RPCs in this service are used by the DTFx worker to process orchestration and activity work items.
+service WorkerBackendService {
+    // Starts a bi-directional stream for receiving work items and sending health pings.
+    rpc GetWorkItems(stream GetWorkItemsRequest) returns (stream WorkItem);
+
+    // Gets orchestration runtime state (history, etc.) for a given orchestration instance.
+    rpc GetOrchestrationRuntimeState (GetOrchestrationRuntimeStateRequest) returns (GetOrchestrationRuntimeStateResponse);
+
+    // Completes an outstanding activity work item and adds a new event to the target orchestration's inbox.
+    rpc CompleteActivityWorkItem (CompleteActivityWorkItemRequest) returns (google.protobuf.Empty);
+
+    // Abandons an outstanding activity work item. Abandoned work items will be delivered again after some delay.
+    rpc AbandonActivityWorkItem (AbandonActivityWorkItemRequest) returns (google.protobuf.Empty);
+
+    // Completes an outstanding orchestrator work item, and adds a new event to the target orchestration's inbox.
+    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (google.protobuf.Empty);
+
+    // Abandons an outstanding orchestrator work item. Abandoned work items will be delivered again after some delay.
+    rpc AbandonOrchestrationWorkItem (AbandonOrchestrationWorkItemRequest) returns (google.protobuf.Empty);
+
+    // Fetches metadata about the connected service. This may also be used to verify connectivity.
+    rpc Metadata(google.protobuf.Empty) returns (google.protobuf.Empty); // TODO: Payloads
+}
+
+// Request payload for adding new orchestration events.
+message AddOrchestrationEventRequest {
+    // The ID of the orchestration to send an event to.
+    OrchestrationInstance instance = 1;
+    // The event to send to the orchestration.
+    HistoryEvent event = 2;
+}
+
+// Request parameters for fetching orchestration runtime state.
+message GetOrchestrationRuntimeStateRequest {
+    // The ID of the target orchestration instance.
+    OrchestrationInstance instance = 1;
+}
+
+// Response payload returned when fetching orchestration runtime state.
+message GetOrchestrationRuntimeStateResponse {
+    // The existing history events for the target orchestration instance.
+    repeated HistoryEvent history = 1;
+}
+
+// Request payload for completing an activity work item.
+message CompleteActivityWorkItemRequest {
+    // The completion token that was provided when the work item was fetched.
+    string completionToken = 1;
+
+    // The response event that will be sent to the orchestrator.
+    // This must be either a TaskCompleted event or a TaskFailed event.
+    HistoryEvent responseEvent = 2;
+}
+
+// Request payload for abandoning an activity work item.
+message AbandonActivityWorkItemRequest {
+    // The completion token that was provided when the work item was fetched.
+    string completionToken = 1;
+}
+
+// Request payload for completing an orchestration work item.
+message CompleteOrchestrationWorkItemRequest {
+    // The completion token that was provided when the work item was fetched.
+    string completionToken = 1;
+    OrchestrationInstance instance = 2;
+    OrchestrationStatus runtimeStatus = 3;
+    google.protobuf.StringValue customStatus = 4;
+	repeated HistoryEvent newHistory = 5;
+    repeated HistoryEvent newTasks = 6;
+    repeated HistoryEvent newTimers = 7;
+    repeated OrchestratorMessage newMessages = 8;
+}
+
+// A message to be delivered to an orchestration by the backend.
+message OrchestratorMessage {
+    // The ID of the orchestration instance to receive the message.
+    OrchestrationInstance instance = 1;
+    // The event payload to be received by the target orchestration.
+	HistoryEvent event = 2;
+}
+
+// Request payload for abandoning an orchestration work item.
+message AbandonOrchestrationWorkItemRequest {
+    // The completion token that was provided when the work item was fetched.
+    string completionToken = 1;
+}

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -106,7 +106,7 @@ message CompleteOrchestrationWorkItemRequest {
     OrchestrationInstance instance = 2;
     OrchestrationStatus runtimeStatus = 3;
     google.protobuf.StringValue customStatus = 4;
-	repeated HistoryEvent newHistory = 5;
+    repeated HistoryEvent newHistory = 5;
     repeated HistoryEvent newTasks = 6;
     repeated HistoryEvent newTimers = 7;
     repeated OrchestratorMessage newMessages = 8;
@@ -117,7 +117,7 @@ message OrchestratorMessage {
     // The ID of the orchestration instance to receive the message.
     OrchestrationInstance instance = 1;
     // The event payload to be received by the target orchestration.
-	HistoryEvent event = 2;
+    HistoryEvent event = 2;
 }
 
 // Request payload for abandoning an orchestration work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -29,13 +29,14 @@ service BackendService {
     // Returns metadata about an orchestration instance.
     rpc GetInstance (GetInstanceRequest) returns (GetInstanceResponse);
 
+    // Returns metadata about multiple orchestration instances using a query.
+    rpc QueryInstances (QueryInstancesRequest) returns (QueryInstancesResponse);
+
     // Waits for an orchestration to reach a terminal state and then returns metadata for that orchestration.
     rpc WaitForInstance (WaitForInstanceRequest) returns (WaitForInstanceResponse);
 
     // Purges the state of one or more orchestration instances.
     rpc PurgeInstances (PurgeInstancesRequest) returns (PurgeInstancesResponse);
-
-    // TODO: Additional operations, such as listing orchestrations
 
     // Starts a server stream for receiving work items
     rpc GetWorkItems (GetWorkItemsRequest) returns (stream WorkItem);

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -17,8 +17,8 @@ import "google/protobuf/wrappers.proto";
 import "google/protobuf/empty.proto";
 
 // gRPC service used by Durable Task Framework (DTFx) backend implementations.
-// The RPCs in this service are used by DTFx clients to manage orchestrations.
-service ClientBackendService {
+// The RPCs in this service are used by DTFx backends to manage orchestration state.
+service BackendService {
     // Creates a new orchestration instance.
     rpc CreateOrchestrationInstance (CreateInstanceRequest) returns (CreateInstanceResponse);
 
@@ -36,13 +36,9 @@ service ClientBackendService {
     rpc PurgeOrchestrationState (PurgeInstancesRequest) returns (PurgeInstancesResponse);
 
     // TODO: Additional operations, such as listing orchestrations
-}
 
-// gRPC service used by Durable Task Framework (DTFx) backend implementations.
-// The RPCs in this service are used by the DTFx worker to process orchestration and activity work items.
-service WorkerBackendService {
-    // Starts a bi-directional stream for receiving work items and sending health pings.
-    rpc GetWorkItems(stream GetWorkItemsRequest) returns (stream WorkItem);
+    // Starts a server stream for receiving work items
+    rpc GetWorkItems(GetWorkItemsRequest) returns (stream WorkItem);
 
     // Gets orchestration runtime state (history, etc.) for a given orchestration instance.
     rpc GetOrchestrationRuntimeState (GetOrchestrationRuntimeStateRequest) returns (GetOrchestrationRuntimeStateResponse);
@@ -59,8 +55,11 @@ service WorkerBackendService {
     // Abandons an outstanding orchestrator work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonOrchestrationWorkItem (AbandonOrchestrationWorkItemRequest) returns (google.protobuf.Empty);
 
-    // Fetches metadata about the connected service. This may also be used to verify connectivity.
+    // Fetches metadata about the connected service.
     rpc Metadata(google.protobuf.Empty) returns (google.protobuf.Empty); // TODO: Payloads
+
+    // Sends a health check ping to the backend service.
+    rpc Ping(google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 
 // Request payload for adding new orchestration events.

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -267,6 +267,8 @@ message CreateInstanceRequest {
     google.protobuf.StringValue input = 4;
     google.protobuf.Timestamp scheduledStartTimestamp = 5;
     OrchestrationIdReusePolicy orchestrationIdReusePolicy = 6;
+    google.protobuf.StringValue executionId = 7;
+    map<string, string> tags = 8;
 }
 
 message OrchestrationIdReusePolicy {
@@ -315,6 +317,9 @@ message OrchestrationState {
     google.protobuf.StringValue output = 9;
     google.protobuf.StringValue customStatus = 10;
     TaskFailureDetails failureDetails = 11;
+    google.protobuf.StringValue executionId = 12;
+    google.protobuf.Timestamp completedTimestamp = 13;
+    google.protobuf.StringValue parentInstanceId = 14;
 }
 
 message RaiseEventRequest {
@@ -609,9 +614,15 @@ message WorkItem {
         OrchestratorRequest orchestratorRequest = 1;
         ActivityRequest activityRequest = 2;
         EntityBatchRequest entityRequest = 3;
+        HealthPing healthPing = 4;
     }
+    string completionToken = 10;
 }
 
 message CompleteTaskResponse {
     // No payload
+}
+
+message HealthPing {
+	// No payload
 }


### PR DESCRIPTION
This PR defines a new gRPC service for a remote backend implementation for the Durable Task Framework (DTFx). It depends on many of the existing message types from `orchestration_service.proto`, such as event history definitions, but defines a few new message types as well.

Implementations of this RPC could be used to build client and server components for custom DTFx backends.