### PR TITLE
Adding GetMetrics RPC to backend service contract

### DIFF
--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -199,7 +199,7 @@ message BackendMetrics {
 // Metrics related to work items
 message WorkItemMetrics {
     // Number of work items that are queued and waiting to be processed
-    int32 pending = 1 [json_name="pending"];;
+    int32 pending = 1 [json_name="pending"];
     // Number of work items that are currently being processed
     int32 active = 2 [json_name="active"];
     // Age of the oldest work item in the queue, in seconds

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -175,13 +175,13 @@ message PingResponse {
 
 // Request payload for fetching backend metrics.
 message GetMetricsRequest {
-	// No fields
+    // No fields
 }
 
 // Response payload for fetching backend metrics
 message GetMetricsResponse {
     // The current metrics for the backend service.
-	BackendMetrics metrics = 1;
+    BackendMetrics metrics = 1;
 }
 
 // Metrics for the backend service.
@@ -209,7 +209,7 @@ message WorkItemMetrics {
 // Metrics related to workers currently connected to the backend
 message ConnectedWorkerMetrics {
     // Number of worker instances that are currently connected to the backend
-	int32 count = 1;
+    int32 count = 1;
     // Total number of orchestrator work items that can be processed concurrently by all connected workers
     int32 totalOrchestratorWorkItemCapacity = 2;
     // Total number of activity work items that can be processed concurrently by all connected workers

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -210,8 +210,4 @@ message WorkItemMetrics {
 message ConnectedWorkerMetrics {
     // Number of worker instances that are currently connected to the backend
     int32 count = 1 [json_name="count"];
-    // Total number of orchestrator work items that can be processed concurrently by all connected workers
-    int32 totalOrchestratorWorkItemCapacity = 2 [json_name="totalOrchestratorWorkItemCapacity"];
-    // Total number of activity work items that can be processed concurrently by all connected workers
-    int32 totalActivityWorkItemCapacity = 3 [json_name="totalActivityWorkItemCapacity"];
 }

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -58,6 +58,9 @@ service BackendService {
 
     // Sends a health check ping to the backend service.
     rpc Ping (PingRequest) returns (PingResponse);
+
+    // Returns the current metrics for the backend service.
+    rpc GetMetrics (GetMetricsRequest) returns (GetMetricsResponse);
 }
 
 // Request payload for adding new orchestration events.
@@ -127,7 +130,7 @@ message AbandonActivityWorkItemResponse {
 message CompleteOrchestrationWorkItemRequest {
     // The completion token that was provided when the work item was fetched.
     string completionToken = 1;
-    google.protobuf.StringValue newExecutionId = 2;
+    OrchestrationInstance instance = 2;
     OrchestrationStatus runtimeStatus = 3;
     google.protobuf.StringValue customStatus = 4;
     repeated HistoryEvent newHistory = 5;
@@ -168,4 +171,47 @@ message PingRequest {
 // Response payload for ping operations.
 message PingResponse {
 	// No fields
+}
+
+// Request payload for fetching backend metrics.
+message GetMetricsRequest {
+	// No fields
+}
+
+// Response payload for fetching backend metrics
+message GetMetricsResponse {
+    // The current metrics for the backend service.
+	BackendMetrics metrics = 1;
+}
+
+// Metrics for the backend service.
+message BackendMetrics {
+    // Activity work item metrics
+    WorkItemMetrics activityWorkItems = 1;
+    // Orchestrator work item metrics
+    WorkItemMetrics orchestratorWorkItems = 2;
+    // Entity work item metrics
+    WorkItemMetrics entityWorkItems = 3;
+    // Metrics related to workers currently connected to the backend
+    ConnectedWorkerMetrics connectedWorkers = 4;
+}
+
+// Metrics related to work items
+message WorkItemMetrics {
+    // Number of work items that are queued and waiting to be processed
+    int32 pending = 1;
+    // Number of work items that are currently being processed
+    int32 active = 2;
+    // Age of the oldest work item in the queue, in seconds
+    int32 oldestAgeInSeconds = 3;
+}
+
+// Metrics related to workers currently connected to the backend
+message ConnectedWorkerMetrics {
+    // Number of worker instances that are currently connected to the backend
+	int32 count = 1;
+    // Total number of orchestrator work items that can be processed concurrently by all connected workers
+    int32 totalOrchestratorWorkItemCapacity = 2;
+    // Total number of activity work items that can be processed concurrently by all connected workers
+    int32 totalActivityWorkItemCapacity = 3;
 }

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -187,31 +187,31 @@ message GetMetricsResponse {
 // Metrics for the backend service.
 message BackendMetrics {
     // Activity work item metrics
-    WorkItemMetrics activityWorkItems = 1;
+    WorkItemMetrics activityWorkItems = 1 [json_name="activityWorkItems"];
     // Orchestrator work item metrics
-    WorkItemMetrics orchestratorWorkItems = 2;
+    WorkItemMetrics orchestratorWorkItems = 2 [json_name="orchestratorWorkItems"];
     // Entity work item metrics
-    WorkItemMetrics entityWorkItems = 3;
+    WorkItemMetrics entityWorkItems = 3 [json_name="entityWorkItems"];
     // Metrics related to workers currently connected to the backend
-    ConnectedWorkerMetrics connectedWorkers = 4;
+    ConnectedWorkerMetrics connectedWorkers = 4 [json_name="connectedWorkers"];
 }
 
 // Metrics related to work items
 message WorkItemMetrics {
     // Number of work items that are queued and waiting to be processed
-    int32 pending = 1;
+    int32 pending = 1 [json_name="pending"];;
     // Number of work items that are currently being processed
-    int32 active = 2;
+    int32 active = 2 [json_name="active"];
     // Age of the oldest work item in the queue, in seconds
-    int32 oldestAgeInSeconds = 3;
+    int32 oldestAgeInSeconds = 3 [json_name="oldestAgeInSeconds"];
 }
 
 // Metrics related to workers currently connected to the backend
 message ConnectedWorkerMetrics {
     // Number of worker instances that are currently connected to the backend
-    int32 count = 1;
+    int32 count = 1 [json_name="count"];
     // Total number of orchestrator work items that can be processed concurrently by all connected workers
-    int32 totalOrchestratorWorkItemCapacity = 2;
+    int32 totalOrchestratorWorkItemCapacity = 2 [json_name="totalOrchestratorWorkItemCapacity"];
     // Total number of activity work items that can be processed concurrently by all connected workers
-    int32 totalActivityWorkItemCapacity = 3;
+    int32 totalActivityWorkItemCapacity = 3 [json_name="totalActivityWorkItemCapacity"];
 }


### PR DESCRIPTION
Created a new API in `backend_service.proto` called `GetMetrics`, which returns a metrics payload to the caller. The intended use case is for backend clients to fetch metrics that can be used for making dynamic scale decisions.