### PR TITLE
add concurrency limits to GetWorkItemsRequest

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -607,7 +607,8 @@ service TaskHubSidecarService {
 }
 
 message GetWorkItemsRequest {
-    // No parameters currently
+    int32 maxConcurrentOrchestrationWorkItems = 1;
+    int32 maxConcurrentActivityWorkItems = 2;
 }
 
 message WorkItem {


### PR DESCRIPTION
Adding fields so a client that connects to the backend can inform the backend about the maximum number of concurrent orchestration and activity work items it can handle.

This is useful for implementing server-side flow control for work items.