### PR TITLE
Add completion token fields to activity and orchestrator response messages

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -31,6 +31,7 @@ message ActivityResponse {
     int32 taskId = 2;
     google.protobuf.StringValue result = 3;
     TaskFailureDetails failureDetails = 4;
+    string completionToken = 5;
 }
 
 message TaskFailureDetails {
@@ -259,6 +260,7 @@ message OrchestratorResponse {
     string instanceId = 1;
     repeated OrchestratorAction actions = 2;
     google.protobuf.StringValue customStatus = 3;
+    string completionToken = 4;
 }
 
 message CreateInstanceRequest {
@@ -427,20 +429,17 @@ message SignalEntityResponse {
      // no payload
 }
 
-message GetEntityRequest
-{
+message GetEntityRequest {
     string instanceId = 1;
     bool includeState = 2;
 }
 
-message GetEntityResponse
-{
+message GetEntityResponse {
     bool exists = 1;
     EntityMetadata entity = 2;
 }
 
-message EntityQuery
-{
+message EntityQuery {
     google.protobuf.StringValue instanceIdStartsWith = 1;
     google.protobuf.Timestamp lastModifiedFrom = 2;
     google.protobuf.Timestamp lastModifiedTo = 3;
@@ -450,19 +449,16 @@ message EntityQuery
     google.protobuf.StringValue continuationToken = 7;
 }
 
-message QueryEntitiesRequest
-{
+message QueryEntitiesRequest {
     EntityQuery query = 1;
 }
 
-message QueryEntitiesResponse
-{
+message QueryEntitiesResponse {
     repeated EntityMetadata entities = 1;
     google.protobuf.StringValue continuationToken = 2;
 }
 
-message EntityMetadata
-{
+message EntityMetadata {
     string instanceId = 1;
     google.protobuf.Timestamp lastModifiedTime = 2;
     int32 backlogQueueSize = 3;
@@ -470,22 +466,19 @@ message EntityMetadata
     google.protobuf.StringValue serializedState = 5;
 }
 
-message CleanEntityStorageRequest
-{
+message CleanEntityStorageRequest {
     google.protobuf.StringValue continuationToken = 1;
     bool removeEmptyEntities = 2;
     bool releaseOrphanedLocks = 3;
 }
 
-message CleanEntityStorageResponse
-{
+message CleanEntityStorageResponse {
     google.protobuf.StringValue continuationToken = 1;
     int32 emptyEntitiesRemoved = 2;
     int32 orphanedLocksReleased = 3;
 }
 
-message OrchestratorEntityParameters
-{
+message OrchestratorEntityParameters {
     google.protobuf.Duration entityMessageReorderWindow = 1;
 }
 


### PR DESCRIPTION
This PR adds `completionToken` fields to the `ActivityResponse` and `OrchestratorResponse` messages in the `protos/orchestrator_service.proto` file. SDKs using these message types should populate these fields with the `completionToken` value of the corresponding `WorkItem` message received from the sidecar/backend.

This change is needed for better correlation of completions and work items.

Also included in this PR are some whitespace formatting fixes.