### PR TITLE
Pollable Purge Instances

### DIFF
--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -44,6 +44,9 @@ service BackendService {
     // Purges the state of one or more orchestration instances.
     rpc PurgeInstances (PurgeInstancesRequest) returns (PurgeInstancesResponse);
 
+    // Gets the status of an orchestration purge operation.
+    rpc GetOperationResult (GetOperationResultRequest) returns (GetOperationResultResponse);
+
     // Cleans entity storage.
     rpc CleanEntityStorage(CleanEntityStorageRequest) returns (CleanEntityStorageResponse);
 

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -453,6 +453,7 @@ message PurgeInstancesRequest {
         PurgeInstanceFilter purgeInstanceFilter = 2;
     }
     bool recursive = 3;
+    bool pollable = 4;
 }
 
 message PurgeInstanceFilter {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -463,6 +463,20 @@ message PurgeInstanceFilter {
 
 message PurgeInstancesResponse {
     int32 deletedInstanceCount = 1;
+    string operationId = 2;
+}
+
+message GetOperationResultRequest {
+    string operationId = 1;
+}
+
+message GetOperationResultResponse {
+    string operationId = 1;
+    string status = 2;
+    int32 deletedInstanceCount = 3;
+    string errorMessage = 4;
+    google.protobuf.Timestamp createdTime = 5;
+    google.protobuf.Timestamp lastUpdatedTime = 6;
 }
 
 message CreateTaskHubRequest {
@@ -652,6 +666,7 @@ service TaskHubSidecarService {
 
     rpc QueryInstances(QueryInstancesRequest) returns (QueryInstancesResponse);
     rpc PurgeInstances(PurgeInstancesRequest) returns (PurgeInstancesResponse);
+    rpc GetOperationResult(GetOperationResultRequest) returns (GetOperationResultResponse);
 
     rpc GetWorkItems(GetWorkItemsRequest) returns (stream WorkItem);
     rpc CompleteActivityTask(ActivityResponse) returns (CompleteTaskResponse);


### PR DESCRIPTION
This pull request includes several changes to the `protos/orchestrator_service.proto` and `protos/backend_service.proto` files to add new functionality for retrieving the status of orchestration purge operations. The most important changes include the addition of a new RPC method, new fields in existing messages, and the creation of new message types.

### Additions to RPC methods:

* [`protos/backend_service.proto`](diffhunk://#diff-ff70a036d8712d6d895d5c9e9980e0973c22e3fff4cb75fa467381a9cbc0ca70R47-R49): Added a new RPC method `GetOperationResult` to the `BackendService` to get the status of an orchestration purge operation.
* [`protos/orchestrator_service.proto`](diffhunk://#diff-1a29f05d707748da230a5e02a23225ece4272a3cbf247817ae47dc673f466150R670): Added a new RPC method `GetOperationResult` to the `TaskHubSidecarService` to retrieve the operation result.

### Modifications to existing messages:

* [`protos/orchestrator_service.proto`](diffhunk://#diff-1a29f05d707748da230a5e02a23225ece4272a3cbf247817ae47dc673f466150R456): Added a `pollable` field to the `PurgeInstancesRequest` message to indicate if the operation is pollable.
* [`protos/orchestrator_service.proto`](diffhunk://#diff-1a29f05d707748da230a5e02a23225ece4272a3cbf247817ae47dc673f466150R467-R480): Added an `operationId` field to the `PurgeInstancesResponse` message to track the operation.

### New message types:

* [`protos/orchestrator_service.proto`](diffhunk://#diff-1a29f05d707748da230a5e02a23225ece4272a3cbf247817ae47dc673f466150R467-R480): Created new message types `GetOperationResultRequest` and `GetOperationResultResponse` to handle the request and response for getting the operation result.