### PR TITLE
Add isComplete field to PurgeInstancesResponse in orchestrator servic…

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -463,7 +463,7 @@ message PurgeInstanceFilter {
 
 message PurgeInstancesResponse {
     int32 deletedInstanceCount = 1;
-    bool isComplete = 2;
+    google.protobuf.BoolValue isComplete = 2;
 }
 
 message CreateTaskHubRequest {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -463,6 +463,7 @@ message PurgeInstanceFilter {
 
 message PurgeInstancesResponse {
     int32 deletedInstanceCount = 1;
+    bool isComplete = 2;
 }
 
 message CreateTaskHubRequest {


### PR DESCRIPTION
This pull request includes a small change to the `protos/orchestrator_service.proto` file. The change adds a new boolean field `isComplete` to the `PurgeInstancesResponse` message.

* [`protos/orchestrator_service.proto`](diffhunk://#diff-1a29f05d707748da230a5e02a23225ece4272a3cbf247817ae47dc673f466150R466): Added a new boolean field `isComplete` to the `PurgeInstancesResponse` message.