### PR TITLE
Distributed Tracing for Entities (Isolated)

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -573,7 +573,7 @@ message OperationRequest {
     string operation = 1;
     string requestId = 2;
     google.protobuf.StringValue input = 3;
-    TraceContext TraceContext = 4;
+    TraceContext traceContext = 4;
 }
 
 message OperationResult {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -574,6 +574,7 @@ message OperationRequest {
     string requestId = 2;
     google.protobuf.StringValue input = 3;
     TraceContext TraceContext = 4;
+    string TraceParent = 5;
 }
 
 message OperationResult {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -590,14 +590,12 @@ message OperationInfo {
 
 message OperationResultSuccess {
     google.protobuf.StringValue result = 1;
-    google.protobuf.Timestamp startTime = 2;
-    google.protobuf.Timestamp endTime = 3;
+    google.protobuf.Timestamp endTime = 2;
 }
 
 message OperationResultFailure {
     TaskFailureDetails failureDetails = 1;
-    google.protobuf.Timestamp startTime = 2;
-    google.protobuf.Timestamp endTime = 3;
+    google.protobuf.Timestamp endTime = 2;
 }
 
 message OperationAction {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -573,6 +573,7 @@ message OperationRequest {
     string operation = 1;
     string requestId = 2;
     google.protobuf.StringValue input = 3;
+    TraceContext TraceContext = 4;
 }
 
 message OperationResult {
@@ -608,6 +609,7 @@ message SendSignalAction {
     string name = 2;
     google.protobuf.StringValue input = 3;
     google.protobuf.Timestamp scheduledTime = 4;
+    TraceContext parentTraceContext = 5;
 }
 
 message StartNewOrchestrationAction {
@@ -616,6 +618,7 @@ message StartNewOrchestrationAction {
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
     google.protobuf.Timestamp scheduledTime = 5;
+    TraceContext parentTraceContext = 6;
 }
 
 service TaskHubSidecarService {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -487,6 +487,7 @@ message SignalEntityRequest {
     google.protobuf.StringValue input = 3;
     string requestId = 4;
     google.protobuf.Timestamp scheduledTime = 5;
+    TraceContext parentTraceContext = 6;
 }
 
 message SignalEntityResponse {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -592,12 +592,14 @@ message OperationInfo {
 
 message OperationResultSuccess {
     google.protobuf.StringValue result = 1;
-    google.protobuf.Timestamp endTime = 2;
+    google.protobuf.Timestamp startTime = 2;
+    google.protobuf.Timestamp endTime = 3;
 }
 
 message OperationResultFailure {
     TaskFailureDetails failureDetails = 1;
-    google.protobuf.Timestamp endTime = 2;
+    google.protobuf.Timestamp startTime = 2;
+    google.protobuf.Timestamp endTime = 3;
 }
 
 message OperationAction {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -595,14 +595,14 @@ message OperationInfo {
 
 message OperationResultSuccess {
     google.protobuf.StringValue result = 1;
-    google.protobuf.Timestamp startTime = 2;
-    google.protobuf.Timestamp endTime = 3;
+    google.protobuf.Timestamp startTimeUtc = 2;
+    google.protobuf.Timestamp endTimeUtc = 3;
 }
 
 message OperationResultFailure {
     TaskFailureDetails failureDetails = 1;
-    google.protobuf.Timestamp startTime = 2;
-    google.protobuf.Timestamp endTime = 3;
+    google.protobuf.Timestamp startTimeUtc = 2;
+    google.protobuf.Timestamp endTimeUtc = 3;
 }
 
 message OperationAction {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -341,6 +341,7 @@ message CreateInstanceRequest {
     google.protobuf.StringValue executionId = 7;
     map<string, string> tags = 8;
     TraceContext parentTraceContext = 9;
+    google.protobuf.Timestamp requestTime = 10;
 }
 
 message OrchestrationIdReusePolicy {
@@ -488,6 +489,7 @@ message SignalEntityRequest {
     string requestId = 4;
     google.protobuf.Timestamp scheduledTime = 5;
     TraceContext parentTraceContext = 6;
+    google.protobuf.Timestamp requestTime = 7;
 }
 
 message SignalEntityResponse {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -574,7 +574,6 @@ message OperationRequest {
     string requestId = 2;
     google.protobuf.StringValue input = 3;
     TraceContext TraceContext = 4;
-    string TraceParent = 5;
 }
 
 message OperationResult {
@@ -591,10 +590,14 @@ message OperationInfo {
 
 message OperationResultSuccess {
     google.protobuf.StringValue result = 1;
+    google.protobuf.Timestamp startTime = 2;
+    google.protobuf.Timestamp endTime = 3;
 }
 
 message OperationResultFailure {
     TaskFailureDetails failureDetails = 1;
+    google.protobuf.Timestamp startTime = 2;
+    google.protobuf.Timestamp endTime = 3;
 }
 
 message OperationAction {
@@ -610,7 +613,8 @@ message SendSignalAction {
     string name = 2;
     google.protobuf.StringValue input = 3;
     google.protobuf.Timestamp scheduledTime = 4;
-    TraceContext parentTraceContext = 5;
+    google.protobuf.Timestamp requestTime = 5;
+    TraceContext parentTraceContext = 6;
 }
 
 message StartNewOrchestrationAction {
@@ -619,7 +623,8 @@ message StartNewOrchestrationAction {
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
     google.protobuf.Timestamp scheduledTime = 5;
-    TraceContext parentTraceContext = 6;
+    google.protobuf.Timestamp requestTime = 6;
+    TraceContext parentTraceContext = 7;
 }
 
 service TaskHubSidecarService {


### PR DESCRIPTION
This PR adds new fields to protobuf objects related to signaling entities or entities starting an orchestration to correctly enable distributed tracing for entities in the .NET isolated framework. The fields propagate parent trace context information to make sure that the traces are correctly linked together (i.e. that the trace corresponding to a signal entity request becomes the parent of the trace corresponding to that request being processed). They also propagate the time a request was created or completed in order to correctly set the start and end time of the corresponding traces. 

The various other PRs related to this effort are
- [WebJobs](https://github.com/Azure/azure-functions-durable-extension/pull/3076)
- [durabletask-dotnet](https://github.com/microsoft/durabletask-dotnet/pull/404)
- [durabletask](https://github.com/Azure/durabletask/pull/1198)