### PR TITLE
Add properties Field to OrchestratorRequest

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -318,6 +318,7 @@ message OrchestratorRequest {
     repeated HistoryEvent newEvents = 4;
     OrchestratorEntityParameters entityParameters = 5;
     bool requiresHistoryStreaming = 6;
+    map<string, google.protobuf.Value> orchestratorContextConfig = 7;
 }
 
 message OrchestratorResponse {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -318,7 +318,7 @@ message OrchestratorRequest {
     repeated HistoryEvent newEvents = 4;
     OrchestratorEntityParameters entityParameters = 5;
     bool requiresHistoryStreaming = 6;
-    map<string, google.protobuf.Value> orchestratorContextConfig = 7;
+    map<string, google.protobuf.Value> properties = 7;
 }
 
 message OrchestratorResponse {


### PR DESCRIPTION
This PR adds a new map field named `properties` to `OrchestratorRequest`

We are adding a new Dictionary <string, object> at TaskorcehstrationContext in Microsoft.DurableTask. This new field will allow configuration from DurableTaskOptions at WebJobs.Extensions.DurableTasdk can be passed to this dictionary in `TaskOrchestrationContext`

Related PR https://github.com/Azure/azure-functions-durable-extension/pull/3092