### PR TITLE
add missing import for google.protobuf.Value

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -11,6 +11,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
 
 message OrchestrationInstance {
     string instanceId = 1;


### PR DESCRIPTION
This pull request makes a minor update to the `protos/orchestrator_service.proto` file by adding a new import statement for `google/protobuf/struct.proto`. This change likely supports additional functionality or data structures in the protocol buffer definitions.