### PR TITLE
Add tags field to TaskScheduledEvent and ScheduleTaskAction in orchestrator_service.proto

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -95,6 +95,7 @@ message TaskScheduledEvent {
     google.protobuf.StringValue version = 2;
     google.protobuf.StringValue input = 3;
     TraceContext parentTraceContext = 4;
+    map<string, string> tags = 5;
 }
 
 message TaskCompletedEvent {
@@ -256,6 +257,7 @@ message ScheduleTaskAction {
     string name = 1;
     google.protobuf.StringValue version = 2;
     google.protobuf.StringValue input = 3;
+    map<string, string> tags = 4;
 }
 
 message CreateSubOrchestrationAction {


### PR DESCRIPTION
part of change required for activity tagging
This pull request updates the `protos/orchestrator_service.proto` file to include support for `tags` in task-related messages. These changes enhance the protocol buffer definitions to allow additional metadata to be associated with tasks.

### Enhancements to protocol buffer definitions:

* [`message TaskScheduledEvent`](diffhunk://#diff-1a29f05d707748da230a5e02a23225ece4272a3cbf247817ae47dc673f466150R98): Added a `tags` field of type `map<string, string>` to allow attaching metadata to scheduled tasks.
* [`message ScheduleTaskAction`](diffhunk://#diff-1a29f05d707748da230a5e02a23225ece4272a3cbf247817ae47dc673f466150R260): Added a `tags` field of type `map<string, string>` to support metadata for task scheduling actions.