### PR TITLE
Add new tracing properties for .NET E2E traces.

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -77,6 +77,8 @@ message ExecutionStartedEvent {
     TraceContext parentTraceContext = 7;
     google.protobuf.StringValue orchestrationSpanID = 8;
     map<string, string> tags = 9;
+    google.protobuf.StringValue orchestrationActivityID = 10;
+    google.protobuf.Timestamp orchestrationActivityStartTime = 11;
 }
 
 message ExecutionCompletedEvent {
@@ -256,6 +258,7 @@ message ScheduleTaskAction {
     string name = 1;
     google.protobuf.StringValue version = 2;
     google.protobuf.StringValue input = 3;
+    TraceContext parentTraceContext = 4;
 }
 
 message CreateSubOrchestrationAction {
@@ -331,6 +334,10 @@ message OrchestratorResponse {
     // The number of work item events that were processed by the orchestrator.
     // This field is optional. If not set, the service should assume that the orchestrator processed all events.
     google.protobuf.Int32Value numEventsProcessed = 5;
+
+    google.protobuf.StringValue orchestrationActivitySpanID = 6;
+    google.protobuf.StringValue orchestrationActivityID = 7;
+    google.protobuf.Timestamp orchestrationActivityStartTime = 8;
 }
 
 message CreateInstanceRequest {


### PR DESCRIPTION
Using the azure managed backend (i.e. Durable Task Scheduler) with .NET, in both the case of DTFx and Portable SDKs, the gRPC API is missing properties needed to generate spans for a complete orchestration execution.  This change adds those missing properties.

The DTFx SDK expects the a (native) `ExecutionStartedEvent` to contain a parent trace context that exposes a tuple with the orchestration activity ID/span ID/start time.  This tuple is generated on initial execution of the orchestration, set on the `ExecutionStartedEvent`, and then expected to be passed back on subsequent executions.  These properties enable the SDK to reuse a .NET tracing `Activity` that represents then entire orchestration, even though they are, in fact, separate instances.  The gRPC `ExecutionStarted` event today contains only the `orchestrationSpanID`.

The gRPC `TaskScheduled` event given to workers contains a `parentTraceContext` property which enables workers to parent traces related to task execution. However, the gRPC `ScheduleTaskAction` returned by the worker that generates subsequent `TaskScheduled` events does *not* have a parent trace context property.  This prevents tasks traces from being parented to orchestration-level traces.

The gRPC API does not return the `ExecutionStarted` event to the backend (as in the case of DTFx).  This means that event cannot be used to return orchestration-related tracing properties to the backend to be returned on subsequent executions.  Instead, I propose those properties be returned via the `OrchestratorResponse` object directly.  The backend could then inject them into the `ExecutionStarted` event on subsequent execution in order to be consistent with and reuse properties used by DTFx.  (Alternatively, those properties could be added to `OrchestratorRequest`.)