### PR TITLE
Add properties Field to TaskFailureDetails

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -41,6 +41,7 @@ message TaskFailureDetails {
     google.protobuf.StringValue stackTrace = 3;
     TaskFailureDetails innerFailure = 4;
     bool isNonRetriable = 5;
+    map<string, google.protobuf.Value> properties = 6;
 }
 
 enum OrchestrationStatus {


### PR DESCRIPTION
This PR adds a new field `properties` to TaskFailureDetails, which is intended to store the properties of exceptions encountered during Durable Task execution.