### PR TITLE
Add RestartInstance RPC method to orchestrator service

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -471,6 +471,11 @@ message PurgeInstancesResponse {
     google.protobuf.BoolValue isComplete = 2;
 }
 
+message RestartInstanceRequest {
+    string instanceId = 1;
+    bool restartWithNewInstanceId = 2;
+}
+
 message CreateTaskHubRequest {
     bool recreateIfExists = 1;
 }
@@ -670,6 +675,9 @@ service TaskHubSidecarService {
 
     // Rewinds an orchestration instance to last known good state and replays from there.
     rpc RewindInstance(RewindInstanceRequest) returns (RewindInstanceResponse);
+
+    // Restarts an orchestration instance.
+    rpc RestartInstance(RestartInstanceRequest) returns (CreateInstanceResponse);
 
     // Waits for an orchestration instance to reach a running or completion state.
     rpc WaitForInstanceStart(GetInstanceRequest) returns (GetInstanceResponse);

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -476,6 +476,10 @@ message RestartInstanceRequest {
     bool restartWithNewInstanceId = 2;
 }
 
+message RestartInstanceResponse {
+    string instanceId = 1;
+}
+
 message CreateTaskHubRequest {
     bool recreateIfExists = 1;
 }
@@ -677,7 +681,7 @@ service TaskHubSidecarService {
     rpc RewindInstance(RewindInstanceRequest) returns (RewindInstanceResponse);
 
     // Restarts an orchestration instance.
-    rpc RestartInstance(RestartInstanceRequest) returns (CreateInstanceResponse);
+    rpc RestartInstance(RestartInstanceRequest) returns (RestartInstanceResponse);
 
     // Waits for an orchestration instance to reach a running or completion state.
     rpc WaitForInstanceStart(GetInstanceRequest) returns (GetInstanceResponse);


### PR DESCRIPTION
This PR is part of support of issue https://github.com/Azure/azure-functions-durable-extension/issues/2903

This PR adds a new `RestartInstance` RPC method to the TaskHubSidecarService that allows restarting orchestration instances with provided instanceId or a new instanceId. 

Updates:
- Add `RestartInstanceRequest` message with `instanceId` and `restartWithNewInstanceId` fields
- Add RestartInstance RPC method that receives `RestartInstanceRequest`  and returns `CreateInstanceResponse`