### PR TITLE
Extended Sessions for Isolated (Orchestrations)

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -333,6 +333,7 @@ message OrchestratorResponse {
     // The number of work item events that were processed by the orchestrator.
     // This field is optional. If not set, the service should assume that the orchestrator processed all events.
     google.protobuf.Int32Value numEventsProcessed = 5;
+    bool requiresHistory = 6;
 }
 
 message CreateInstanceRequest {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -333,6 +333,7 @@ message OrchestratorResponse {
     // The number of work item events that were processed by the orchestrator.
     // This field is optional. If not set, the service should assume that the orchestrator processed all events.
     google.protobuf.Int32Value numEventsProcessed = 5;
+    // Whether or not a history is required to complete the original OrchestratorRequest and none was provided.
     bool requiresHistory = 6;
 }
 


### PR DESCRIPTION
This PR adds a new `historyRequired` field to the `OrchestratorResponse`. This will be used by the dotnet SDK to handle the edge case where it has since ended an extended session and needs an orchestration history in order to replay the orchestration up to the execution point, but none was provided in the `OrchestratorRequest`. The SDK will set the `historyRequired` field in the response to true, in which case the host will end the extended session and attach a history in the next `OrchestratorRequest` (specifically, as discussed in this [PR](https://github.com/Azure/azure-functions-durable-extension/pull/3154), the [`OutOfProcMiddleware`](https://github.com/Azure/azure-functions-durable-extension/blob/dev/src/WebJobs.Extensions.DurableTask/OutOfProcMiddleware.cs) class will check for this flag in the response and throw a `SessionAbortedException` in the case that it is true). 