### PR TITLE
Add InstanceBatch and Batch Purge

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -467,7 +467,7 @@ message PurgeInstancesRequest {
     oneof request {
         string instanceId = 1;
         PurgeInstanceFilter purgeInstanceFilter = 2;
-        PurgeInstancesList purgeInstancesList = 4;
+        InstanceBatch instanceBatch = 4;
     }
     bool recursive = 3;
 }
@@ -476,10 +476,6 @@ message PurgeInstanceFilter {
     google.protobuf.Timestamp createdTimeFrom = 1;
     google.protobuf.Timestamp createdTimeTo = 2;
     repeated OrchestrationStatus runtimeStatus = 3;
-}
-
-message PurgeInstancesList {
-    repeated string instanceIds = 1;
 }
 
 message PurgeInstancesResponse {
@@ -821,4 +817,8 @@ message StreamInstanceHistoryRequest {
 
 message HistoryChunk {
     repeated HistoryEvent events = 1;
+}
+
+message InstanceBatch {
+    repeated string instanceIds = 1;
 }

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -467,7 +467,7 @@ message PurgeInstancesRequest {
     oneof request {
         string instanceId = 1;
         PurgeInstanceFilter purgeInstanceFilter = 2;
-        repeated string instanceIds = 4;
+        PurgeInstancesList purgeInstancesList = 4;
     }
     bool recursive = 3;
 }
@@ -476,6 +476,10 @@ message PurgeInstanceFilter {
     google.protobuf.Timestamp createdTimeFrom = 1;
     google.protobuf.Timestamp createdTimeTo = 2;
     repeated OrchestrationStatus runtimeStatus = 3;
+}
+
+message PurgeInstancesList {
+    repeated string instanceIds = 1;
 }
 
 message PurgeInstancesResponse {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -467,6 +467,7 @@ message PurgeInstancesRequest {
     oneof request {
         string instanceId = 1;
         PurgeInstanceFilter purgeInstanceFilter = 2;
+        repeated string instanceIds = 4;
     }
     bool recursive = 3;
 }

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -680,8 +680,7 @@ message AbandonEntityTaskResponse {
 }
 
 message SkipGracefulOrchestrationTerminationsRequest {
-    // A maximum of 500 instance IDs can be provided in this list.
-    repeated string instanceIds = 1;
+    InstanceBatch instanceBatch = 1;
     google.protobuf.StringValue reason = 2;
 }
 
@@ -820,5 +819,6 @@ message HistoryChunk {
 }
 
 message InstanceBatch {
+    // A maximum of 500 instance IDs can be provided in this list.
     repeated string instanceIds = 1;
 }


### PR DESCRIPTION
This PR introduces a new `InstanceBatch` type to be leveraged across several batch actions. It changes the current `SkipGracefulOrchestrationTerminationsRequest` to use this type, and makes it one of the options for the `PurgeInstancesRequest` as well.