### PR TITLE
Add batch "add events"

### DIFF
--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -112,9 +112,9 @@ message AddEventsRequest {
 
 // Response payload for adding new orchestration events to multiple instances.
 message AddEventsResponse {
-    // Those instances for which events were successfully added.
+    // Those instances for which events were not successfully added.
     // Events may not be successfully added due to capacity issues, or if the target instance does not exist.
-    repeated string successfulInstanceIds = 1;
+    repeated string unsuccessfulInstanceIds = 1;
 }
 
 // Request payload for waiting for instance completion.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -26,6 +26,9 @@ service BackendService {
     // and for sending orchestration lifecycle events, such as terminate, suspend, resume, etc.
     rpc AddEvent (AddEventRequest) returns (AddEventResponse);
 
+    // The same as the AddEvent API, except for sending events to multiple orchestration instances at once.
+    rpc AddEvents (AddEventsRequest) returns (AddEventsResponse);
+
     // Returns metadata about an orchestration instance.
     rpc GetInstance (GetInstanceRequest) returns (GetInstanceResponse);
 
@@ -98,6 +101,17 @@ message AddEventRequest {
 
 // Response payload for adding new orchestration events.
 message AddEventResponse {
+    // No fields
+}
+
+// Request payload for adding new orchestration events to multiple instances.
+message AddEventsRequest {
+    // A map from instance IDs to the event to add to each.
+    map<string, HistoryEvents> events = 1;
+}
+
+// Response payload for adding new orchestration events to multiple instances.
+message AddEventsResponse {
     // No fields
 }
 

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -112,9 +112,9 @@ message AddEventsRequest {
 
 // Response payload for adding new orchestration events to multiple instances.
 message AddEventsResponse {
-    // The number of instances that events were successfully added to.
-    // An event cannot be added if the target instance in the AddEventsRequest does not exist.
-    int32 successfulInstanceCounts = 1;
+    // Those instances for which events were successfully added.
+    // Events may not be successfully added due to capacity issues, or if the target instance does not exist.
+    repeated string successfulInstanceIds = 1;
 }
 
 // Request payload for waiting for instance completion.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -112,7 +112,9 @@ message AddEventsRequest {
 
 // Response payload for adding new orchestration events to multiple instances.
 message AddEventsResponse {
-    // No fields
+    // The number of instances that events were successfully added to.
+    // An event cannot be added if the target instance in the AddEventsRequest does not exist.
+    int32 successfulInstanceCounts = 1;
 }
 
 // Request payload for waiting for instance completion.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -107,7 +107,7 @@ message AddEventResponse {
 // Request payload for adding new orchestration events to multiple instances.
 message AddEventsRequest {
     // A map from instance IDs to the event to add to each.
-    map<string, HistoryEvents> events = 1;
+    map<string, HistoryEvent> events = 1;
 }
 
 // Response payload for adding new orchestration events to multiple instances.


### PR DESCRIPTION
This PR introduces a new proto request/response for adding several orchestration events at once. This new request accepts a dictionary from instance IDs to history events to add to each, and returns the list of instance IDs for which the operation was not successful (if, for example, the instance does not exist in the case that it is a non-entity instance ID).