### PR TITLE
Add opt-in timeout field to PurgeInstanceFilter for partial purge

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -517,6 +517,7 @@ message PurgeInstanceFilter {
     google.protobuf.Timestamp createdTimeFrom = 1;
     google.protobuf.Timestamp createdTimeTo = 2;
     repeated OrchestrationStatus runtimeStatus = 3;
+    google.protobuf.Duration timeout = 4;
 }
 
 message PurgeInstancesResponse {


### PR DESCRIPTION
## Summary

Add `google.protobuf.Duration timeout` field (field 4) to `PurgeInstanceFilter` proto message.

## Changes

- Add `google.protobuf.Duration timeout = 4` to `PurgeInstanceFilter` message

## Behavior

When `timeout` is set:
- The purge operation stops accepting new instance deletions after the specified duration
- Already-dispatched deletions complete before returning
- Response includes `isComplete = false` to indicate more instances remain

When `timeout` is not set (default):
- Existing behavior unchanged — purge runs until all matching instances are deleted

This is opt-in — zero breaking changes. Wire compatible (additive optional field).

Replaces #66 (closed).