### PR TITLE
Adding fields necessary for implementing extended sessions in DTS

### DIFF
--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -72,9 +72,12 @@ service BackendService {
     rpc AbandonActivityWorkItem (AbandonActivityWorkItemRequest) returns (AbandonActivityWorkItemResponse);
 
     // Completes an outstanding orchestrator work item, and adds a new event to the target orchestration's inbox.
+    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (CompleteOrchestrationWorkItemResponse);
+
+    // Completes an outstanding orchestrator work item, and adds a new event to the target orchestration's inbox.
     // Immediately returns a CompleteOrchestrationWorkItemResponse upon committal of the work item, and in the case
     // of an extended session, will continue to stream any new messages to the orchestration until the call is cancelled.
-    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (stream CompleteInstanceWorkItemResponse);
+    rpc CompleteOrchestrationWorkItemWithExtendedSession (CompleteOrchestrationWorkItemRequest) returns (stream CompleteInstanceWorkItemResponse);
 
     // Abandons an outstanding orchestrator work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonOrchestrationWorkItem (AbandonOrchestrationWorkItemRequest) returns (AbandonOrchestrationWorkItemResponse);
@@ -83,9 +86,12 @@ service BackendService {
     rpc ReleaseOrchestrationWorkItem(ReleaseOrchestrationWorkItemRequest) returns (ReleaseOrchestrationWorkItemResponse);
 
     // Completes an outstanding entity work item.
+    rpc CompleteEntityWorkItem (CompleteEntityWorkItemRequest) returns (CompleteEntityWorkItemResponse);
+
+    // Completes an outstanding entity work item.
     // Immediately returns a CompleteEntityWorkItemResponse upon committal of the work item, and in the case
     // of an extended session, will continue to stream any new messages to the entity until the call is cancelled.
-    rpc CompleteEntityWorkItem (CompleteEntityWorkItemRequest) returns (stream CompleteInstanceWorkItemResponse);
+    rpc CompleteEntityWorkItemWithExtendedSession (CompleteEntityWorkItemRequest) returns (stream CompleteInstanceWorkItemResponse);
 
     // Abandons an outstanding entity work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonEntityWorkItem (AbandonEntityWorkItemRequest) returns (AbandonEntityWorkItemResponse);

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -87,7 +87,7 @@ service BackendService {
     rpc AbandonEntityWorkItem (AbandonEntityWorkItemRequest) returns (AbandonEntityWorkItemResponse);
 
     // Releases an entity work item.
-    rpc ReleaseEntityWorkItem(ReleaseEntityWorkItemRequest) returns (ReleaseInstanceWorkItemResponse);
+    rpc ReleaseEntityWorkItem(ReleaseEntityWorkItemRequest) returns (ReleaseEntityWorkItemResponse);
 
     // Sends a health check ping to the backend service.
     rpc Ping (PingRequest) returns (PingResponse);

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -210,9 +210,6 @@ message CompleteOrchestrationWorkItemRequest {
     // This field is omitted for non-chunked completions.
     google.protobuf.Int32Value chunkIndex = 12 [deprecated=true];
 
-    /* Extended sessions fields */
-    bool isExtendedSession = 13;
-
     // Only non-zero in the when extended sessions are active, in which case complete  will be called multiple times
     // for the same instance work item. This field is incremented for each completion call so the backend can identify
     // redundant completion calls for the same set of instance messages.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -253,6 +253,8 @@ message CompleteEntityWorkItemRequest {
     repeated OrchestratorMessage messages = 5;
 
     bool isExtendedSession = 6;
+
+    string instanceId = 7;
 }
 
 // Response payload for completing an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -62,9 +62,6 @@ service BackendService {
     // Gets the history of an orchestration instance as a stream of events.
     rpc StreamInstanceHistory(StreamInstanceHistoryRequest) returns (stream HistoryChunk);
 
-    // Gets pending messages to an instance as a stream of history events.
-    rpc StreamInstanceMessages(StreamInstanceMessagesRequest) returns (stream HistoryChunk);
-
     // Completes an outstanding activity work item and adds a new event to the target orchestration's inbox.
     rpc CompleteActivityWorkItem (CompleteActivityWorkItemRequest) returns (CompleteActivityWorkItemResponse);
 
@@ -327,11 +324,6 @@ message WorkItemMetrics {
 message ConnectedWorkerMetrics {
     // Number of worker instances that are currently connected to the backend
     int32 count = 1 [json_name="count"];
-}
-
-message StreamInstanceMessagesRequest {
-    string instanceId = 1;
-    bool isEntity = 2;
 }
 
 // Request payload for releasing an orchestration work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -330,9 +330,8 @@ message StreamInstanceMessagesRequest {
 
 // Request payload for releasing an orchestration work item.
 message ReleaseOrchestrationWorkItemRequest {
-    string instanceId = 1;
     // The completion token that was provided when the work item was fetched.
-    string completionToken = 2;
+    string completionToken = 1;
 }
 
 // Response payload for releasing an orchestration work item.
@@ -342,9 +341,8 @@ message ReleaseOrchestrationWorkItemResponse {
 
 // Request payload for releasing an entity work item.
 message ReleaseEntityWorkItemRequest {
-    string instanceId = 1;
     // The completion token that was provided when the work item was fetched.
-    string completionToken = 2;
+    string completionToken = 1;
 }
 
 // Response payload for releasing an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -356,11 +356,6 @@ message CompleteInstanceWorkItemResponse {
     oneof request {
         CompleteOrchestrationWorkItemResponse orchestratorResponse = 1;
         CompleteEntityWorkItemResponse entityResponse = 2;
-        NewInstanceMessages newMessages = 3;
+        HistoryChunk newMessages = 3;
     }
-}
-
-message NewInstanceMessages {
-    HistoryChunk newMessages = 1;
-    bool isFinalChunk = 2;
 }

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -247,6 +247,8 @@ message CompleteEntityWorkItemRequest {
     // The messages that were sent by the executed operations. This must
     // include any responses to the operation calls.
     repeated OrchestratorMessage messages = 5;
+
+    bool isExtendedSession = 6;
 }
 
 // Response payload for completing an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -210,8 +210,7 @@ message CompleteOrchestrationWorkItemRequest {
 
 // Response payload for completing an orchestration work item.
 message CompleteOrchestrationWorkItemResponse {
-    // Pending messages to this orchestration, if any.
-	HistoryChunk newMessages = 1;
+    // No fields
 }
 
 // A message to be delivered to an orchestration by the backend.
@@ -258,8 +257,7 @@ message CompleteEntityWorkItemRequest {
 
 // Response payload for completing an entity work item.
 message CompleteEntityWorkItemResponse {
-    // Pending messages to this entity, if any.
-	HistoryChunk newMessages = 1;
+    // No fields
 }
 
 // Request payload for abandoning an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -74,7 +74,7 @@ service BackendService {
     // Completes an outstanding orchestrator work item, and adds a new event to the target orchestration's inbox.
     // Immediately returns a CompleteOrchestrationWorkItemResponse upon committal of the work item, and in the case
     // of an extended session, will continue to stream any new messages to the orchestration until the call is cancelled.
-    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (stream CompleteOrchestrationWorkItemResponse);
+    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (stream CompleteInstanceWorkItemResponse);
 
     // Abandons an outstanding orchestrator work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonOrchestrationWorkItem (AbandonOrchestrationWorkItemRequest) returns (AbandonOrchestrationWorkItemResponse);
@@ -85,7 +85,7 @@ service BackendService {
     // Completes an outstanding entity work item.
     // Immediately returns a CompleteEntityWorkItemResponse upon committal of the work item, and in the case
     // of an extended session, will continue to stream any new messages to the entity until the call is cancelled.
-    rpc CompleteEntityWorkItem (CompleteEntityWorkItemRequest) returns (stream CompleteEntityWorkItemResponse);
+    rpc CompleteEntityWorkItem (CompleteEntityWorkItemRequest) returns (stream CompleteInstanceWorkItemResponse);
 
     // Abandons an outstanding entity work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonEntityWorkItem (AbandonEntityWorkItemRequest) returns (AbandonEntityWorkItemResponse);
@@ -350,4 +350,12 @@ message ReleaseEntityWorkItemRequest {
 // Response payload for releasing an entity work item.
 message ReleaseEntityWorkItemResponse {
 	// No fields
+}
+
+message CompleteInstanceWorkItemResponse {
+    oneof request {
+        CompleteOrchestrationWorkItemResponse orchestratorResponse = 1;
+        CompleteEntityWorkItemResponse entityResponse = 2;
+        HistoryChunk newMessages = 3;
+    }
 }

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -209,6 +209,11 @@ message CompleteOrchestrationWorkItemRequest {
     google.protobuf.Int32Value chunkIndex = 12;
 
     bool isExtendedSession = 13;
+
+    // Only non-zero in the case of chunked completions or when extended sessions are active, in which case complete
+    // will be called multiple times for the same instance work item. This field is incremented for each completion
+    // call so the backend can identify redundant completion calls for the same chunk or set of instance messages.
+    int completionCount = 14;
 }
 
 // Response payload for completing an orchestration work item.
@@ -258,6 +263,12 @@ message CompleteEntityWorkItemRequest {
     bool isExtendedSession = 6;
 
     string instanceId = 7;
+
+    // Only non-zero in the case when an extended sessions is active, in which case complete
+    // will be called multiple times for the same instance work item. This field is incremented
+    // for each completion call so the backend can identify redundant completion calls for the same
+    // set of instance messages.
+    int completionCount = 8;
 }
 
 // Response payload for completing an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -213,7 +213,7 @@ message CompleteOrchestrationWorkItemRequest {
     // Only non-zero in the case of chunked completions or when extended sessions are active, in which case complete
     // will be called multiple times for the same instance work item. This field is incremented for each completion
     // call so the backend can identify redundant completion calls for the same chunk or set of instance messages.
-    int completionCount = 14;
+    int32 completionCount = 14;
 }
 
 // Response payload for completing an orchestration work item.
@@ -268,7 +268,7 @@ message CompleteEntityWorkItemRequest {
     // will be called multiple times for the same instance work item. This field is incremented
     // for each completion call so the backend can identify redundant completion calls for the same
     // set of instance messages.
-    int completionCount = 8;
+    int32 completionCount = 8;
 }
 
 // Response payload for completing an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -62,6 +62,9 @@ service BackendService {
     // Gets the history of an orchestration instance as a stream of events.
     rpc StreamInstanceHistory(StreamInstanceHistoryRequest) returns (stream HistoryChunk);
 
+    // Gets pending messages to an instance as a stream of history events.
+    rpc StreamInstanceMessages(StreamInstanceMessagesRequest) returns (stream HistoryChunk);
+
     // Completes an outstanding activity work item and adds a new event to the target orchestration's inbox.
     rpc CompleteActivityWorkItem (CompleteActivityWorkItemRequest) returns (CompleteActivityWorkItemResponse);
 
@@ -74,11 +77,17 @@ service BackendService {
     // Abandons an outstanding orchestrator work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonOrchestrationWorkItem (AbandonOrchestrationWorkItemRequest) returns (AbandonOrchestrationWorkItemResponse);
 
+    // Releases an orchestration work item.
+    rpc ReleaseOrchestrationWorkItem(ReleaseOrchestrationWorkItemRequest) returns (ReleaseOrchestrationWorkItemResponse);
+
     // Completes an outstanding entity work item.
     rpc CompleteEntityWorkItem (CompleteEntityWorkItemRequest) returns (CompleteEntityWorkItemResponse);
 
     // Abandons an outstanding entity work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonEntityWorkItem (AbandonEntityWorkItemRequest) returns (AbandonEntityWorkItemResponse);
+
+    // Releases an entity work item.
+    rpc ReleaseEntityWorkItem(ReleaseEntityWorkItemRequest) returns (ReleaseInstanceWorkItemResponse);
 
     // Sends a health check ping to the backend service.
     rpc Ping (PingRequest) returns (PingResponse);
@@ -191,6 +200,8 @@ message CompleteOrchestrationWorkItemRequest {
     // Zero-based position of the current chunk within a chunked completion sequence.
     // This field is omitted for non-chunked completions.
     google.protobuf.Int32Value chunkIndex = 12;
+
+    bool isExtendedSession = 13;
 }
 
 // Response payload for completing an orchestration work item.
@@ -302,4 +313,31 @@ message WorkItemMetrics {
 message ConnectedWorkerMetrics {
     // Number of worker instances that are currently connected to the backend
     int32 count = 1 [json_name="count"];
+}
+
+message StreamInstanceMessagesRequest {
+    string instanceId = 1;
+    bool isEntity = 2;
+}
+
+// Request payload for releasing an orchestration work item.
+message ReleaseOrchestrationWorkItemRequest {
+    // The completion token that was provided when the work item was fetched.
+    string completionToken = 1;
+}
+
+// Response payload for releasing an orchestration work item.
+message ReleaseOrchestrationWorkItemResponse {
+	// No fields
+}
+
+// Request payload for releasing an entity work item.
+message ReleaseEntityWorkItemRequest {
+    // The completion token that was provided when the work item was fetched.
+    string completionToken = 1;
+}
+
+// Response payload for releasing an entity work item.
+message ReleaseEntityWorkItemResponse {
+	// No fields
 }

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -72,7 +72,9 @@ service BackendService {
     rpc AbandonActivityWorkItem (AbandonActivityWorkItemRequest) returns (AbandonActivityWorkItemResponse);
 
     // Completes an outstanding orchestrator work item, and adds a new event to the target orchestration's inbox.
-    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (CompleteOrchestrationWorkItemResponse);
+    // Immediately returns a CompleteOrchestrationWorkItemResponse upon committal of the work item, and in the case
+    // of an extended session, will continue to stream any new messages to the orchestration until the call is cancelled.
+    rpc CompleteOrchestrationWorkItem (CompleteOrchestrationWorkItemRequest) returns (stream CompleteOrchestrationWorkItemResponse);
 
     // Abandons an outstanding orchestrator work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonOrchestrationWorkItem (AbandonOrchestrationWorkItemRequest) returns (AbandonOrchestrationWorkItemResponse);
@@ -81,7 +83,9 @@ service BackendService {
     rpc ReleaseOrchestrationWorkItem(ReleaseOrchestrationWorkItemRequest) returns (ReleaseOrchestrationWorkItemResponse);
 
     // Completes an outstanding entity work item.
-    rpc CompleteEntityWorkItem (CompleteEntityWorkItemRequest) returns (CompleteEntityWorkItemResponse);
+    // Immediately returns a CompleteEntityWorkItemResponse upon committal of the work item, and in the case
+    // of an extended session, will continue to stream any new messages to the entity until the call is cancelled.
+    rpc CompleteEntityWorkItem (CompleteEntityWorkItemRequest) returns (stream CompleteEntityWorkItemResponse);
 
     // Abandons an outstanding entity work item. Abandoned work items will be delivered again after some delay.
     rpc AbandonEntityWorkItem (AbandonEntityWorkItemRequest) returns (AbandonEntityWorkItemResponse);
@@ -206,7 +210,8 @@ message CompleteOrchestrationWorkItemRequest {
 
 // Response payload for completing an orchestration work item.
 message CompleteOrchestrationWorkItemResponse {
-	// No fields
+    // Pending messages to this orchestration, if any.
+	repeated HistoryEvent newMessages = 1;
 }
 
 // A message to be delivered to an orchestration by the backend.
@@ -253,7 +258,8 @@ message CompleteEntityWorkItemRequest {
 
 // Response payload for completing an entity work item.
 message CompleteEntityWorkItemResponse {
-    // No fields
+    // Pending messages to this entity, if any.
+	repeated HistoryEvent newMessages = 1;
 }
 
 // Request payload for abandoning an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -211,7 +211,7 @@ message CompleteOrchestrationWorkItemRequest {
 // Response payload for completing an orchestration work item.
 message CompleteOrchestrationWorkItemResponse {
     // Pending messages to this orchestration, if any.
-	repeated HistoryChunk newMessages = 1;
+	HistoryChunk newMessages = 1;
 }
 
 // A message to be delivered to an orchestration by the backend.
@@ -259,7 +259,7 @@ message CompleteEntityWorkItemRequest {
 // Response payload for completing an entity work item.
 message CompleteEntityWorkItemResponse {
     // Pending messages to this entity, if any.
-	repeated HistoryChunk newMessages = 1;
+	HistoryChunk newMessages = 1;
 }
 
 // Request payload for abandoning an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -354,6 +354,11 @@ message CompleteInstanceWorkItemResponse {
     oneof request {
         CompleteOrchestrationWorkItemResponse orchestratorResponse = 1;
         CompleteEntityWorkItemResponse entityResponse = 2;
-        HistoryChunk newMessages = 3;
+        NewInstanceMessages newMessages = 3;
     }
+}
+
+message NewInstanceMessages {
+    HitoryChunk newMessages = 1;
+    bool isFinalChunk = 2;
 }

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -359,6 +359,6 @@ message CompleteInstanceWorkItemResponse {
 }
 
 message NewInstanceMessages {
-    HitoryChunk newMessages = 1;
+    HistoryChunk newMessages = 1;
     bool isFinalChunk = 2;
 }

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -260,8 +260,6 @@ message CompleteEntityWorkItemRequest {
     // include any responses to the operation calls.
     repeated OrchestratorMessage messages = 5;
 
-    bool isExtendedSession = 6;
-
     string instanceId = 7;
 
     // Only non-zero in the when extended sessions are active, in which case complete  will be called multiple times

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -211,7 +211,7 @@ message CompleteOrchestrationWorkItemRequest {
 // Response payload for completing an orchestration work item.
 message CompleteOrchestrationWorkItemResponse {
     // Pending messages to this orchestration, if any.
-	repeated HistoryEvent newMessages = 1;
+	repeated HistoryChunk newMessages = 1;
 }
 
 // A message to be delivered to an orchestration by the backend.
@@ -259,7 +259,7 @@ message CompleteEntityWorkItemRequest {
 // Response payload for completing an entity work item.
 message CompleteEntityWorkItemResponse {
     // Pending messages to this entity, if any.
-	repeated HistoryEvent newMessages = 1;
+	repeated HistoryChunk newMessages = 1;
 }
 
 // Request payload for abandoning an entity work item.

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -322,8 +322,9 @@ message StreamInstanceMessagesRequest {
 
 // Request payload for releasing an orchestration work item.
 message ReleaseOrchestrationWorkItemRequest {
+    string instanceId = 1;
     // The completion token that was provided when the work item was fetched.
-    string completionToken = 1;
+    string completionToken = 2;
 }
 
 // Response payload for releasing an orchestration work item.
@@ -333,8 +334,9 @@ message ReleaseOrchestrationWorkItemResponse {
 
 // Request payload for releasing an entity work item.
 message ReleaseEntityWorkItemRequest {
+    string instanceId = 1;
     // The completion token that was provided when the work item was fetched.
-    string completionToken = 1;
+    string completionToken = 2;
 }
 
 // Response payload for releasing an entity work item.


### PR DESCRIPTION
This PR introduces a new streaming call for the complete instance work item requests that will stream instance messages back to the extended session. It introduces a new release instance work item set of APIs necessary so that the frontend can release work items once the extended session ends. It also adds various fields to the complete instance work item requests themselves related to this effort.