### PR TITLE
Fix duplicate semicolon in orchestrator proto

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -377,7 +377,7 @@ message OrchestratorResponse {
 
     // Zero-based position of the current chunk within a chunked completion sequence.
     // This field is omitted for non-chunked completions.
-    google.protobuf.Int32Value chunkIndex = 9 [deprecated=true];;
+    google.protobuf.Int32Value chunkIndex = 9 [deprecated=true];
 }
 
 message CreateInstanceRequest {


### PR DESCRIPTION
## Summary
- Remove the extra semicolon from the deprecated `chunkIndex` field in `orchestrator_service.proto`.

## Validation
- `git diff --check`
- `rg ";;" protos`

Note: Gradle build could not run because this environment does not have Java/JAVA_HOME configured.