### PR TITLE
Add large-payload tombstone fetch and purge-result RPCs for blob auto-purge

### DIFF
--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -57,10 +57,15 @@ service BackendService {
     // Starts a server stream for receiving work items
     rpc GetWorkItems (GetWorkItemsRequest) returns (stream WorkItem);
 
-    // Streams tombstoned large-payload blob tokens to a connected worker for deletion; the worker
-    // acks each deleted blob so the backend can hard-delete the corresponding row. Idempotent and
-    // safe with multiple worker replicas (unacked rows stay tombstoned and are re-streamed).
-    rpc PurgeExternalPayloads(stream PayloadPurgeAck) returns (stream TombstonedPayload);
+    // Fetches up to `limit` tombstoned large-payload rows whose external blobs the worker must
+    // delete. The worker (which has storage credentials) deletes each blob, then calls
+    // AckPurgedPayloads so the backend can hard-delete those rows. Idempotent and safe under
+    // retries/duplicate callers (unacked rows stay tombstoned and are returned again).
+    rpc GetTombstonedPayloads(GetTombstonedPayloadsRequest) returns (GetTombstonedPayloadsResponse);
+
+    // Acks tombstoned payloads whose external blobs the worker has deleted; the backend hard-deletes
+    // the corresponding rows. Idempotent and safe under retries/duplicate callers.
+    rpc AckPurgedPayloads(AckPurgedPayloadsRequest) returns (AckPurgedPayloadsResponse);
 
     // Gets orchestration runtime state (history, etc.) for a given orchestration instance.
     rpc GetOrchestrationRuntimeState (GetOrchestrationRuntimeStateRequest) returns (GetOrchestrationRuntimeStateResponse);

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -57,6 +57,11 @@ service BackendService {
     // Starts a server stream for receiving work items
     rpc GetWorkItems (GetWorkItemsRequest) returns (stream WorkItem);
 
+    // Streams tombstoned large-payload blob tokens to a connected worker for deletion; the worker
+    // acks each deleted blob so the backend can hard-delete the corresponding row. Idempotent and
+    // safe with multiple worker replicas (unacked rows stay tombstoned and are re-streamed).
+    rpc PurgeExternalPayloads(stream PayloadPurgeAck) returns (stream TombstonedPayload);
+
     // Gets orchestration runtime state (history, etc.) for a given orchestration instance.
     rpc GetOrchestrationRuntimeState (GetOrchestrationRuntimeStateRequest) returns (GetOrchestrationRuntimeStateResponse);
 

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -57,16 +57,6 @@ service BackendService {
     // Starts a server stream for receiving work items
     rpc GetWorkItems (GetWorkItemsRequest) returns (stream WorkItem);
 
-    // Fetches up to `limit` tombstoned large-payload rows whose external blobs the worker must
-    // delete. The worker (which has storage credentials) deletes each blob, then calls
-    // AckPurgedPayloads so the backend can hard-delete those rows. Idempotent and safe under
-    // retries/duplicate callers (unacked rows stay tombstoned and are returned again).
-    rpc GetTombstonedPayloads(GetTombstonedPayloadsRequest) returns (GetTombstonedPayloadsResponse);
-
-    // Acks tombstoned payloads whose external blobs the worker has deleted; the backend hard-deletes
-    // the corresponding rows. Idempotent and safe under retries/duplicate callers.
-    rpc AckPurgedPayloads(AckPurgedPayloadsRequest) returns (AckPurgedPayloadsResponse);
-
     // Gets orchestration runtime state (history, etc.) for a given orchestration instance.
     rpc GetOrchestrationRuntimeState (GetOrchestrationRuntimeStateRequest) returns (GetOrchestrationRuntimeStateResponse);
 

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -787,10 +787,15 @@ service TaskHubSidecarService {
 
     rpc GetWorkItems(GetWorkItemsRequest) returns (stream WorkItem);
 
-    // Streams tombstoned large-payload blob tokens to a connected worker for deletion; the worker
-    // acks each deleted blob so the backend can hard-delete the corresponding row. Idempotent and
-    // safe with multiple worker replicas (unacked rows stay tombstoned and are re-streamed).
-    rpc PurgeExternalPayloads(stream PayloadPurgeAck) returns (stream TombstonedPayload);
+    // Fetches up to `limit` tombstoned large-payload rows whose external blobs the worker must
+    // delete. The worker (which has storage credentials) deletes each blob, then calls
+    // AckPurgedPayloads so the backend can hard-delete those rows. Idempotent and safe under
+    // retries/duplicate callers (unacked rows stay tombstoned and are returned again).
+    rpc GetTombstonedPayloads(GetTombstonedPayloadsRequest) returns (GetTombstonedPayloadsResponse);
+
+    // Acks tombstoned payloads whose external blobs the worker has deleted; the backend hard-deletes
+    // the corresponding rows. Idempotent and safe under retries/duplicate callers.
+    rpc AckPurgedPayloads(AckPurgedPayloadsRequest) returns (AckPurgedPayloadsResponse);
 
     rpc CompleteActivityTask(ActivityResponse) returns (CompleteTaskResponse);
     rpc CompleteOrchestratorTask(OrchestratorResponse) returns (CompleteTaskResponse);
@@ -844,6 +849,25 @@ message PayloadPurgeAck {
     int32 partitionId = 1;
     int64 instanceKey = 2;
     int64 payloadId   = 3;
+}
+
+// client -> server: request up to `limit` tombstoned payload rows to purge.
+message GetTombstonedPayloadsRequest {
+    int32 limit = 1;
+}
+
+// server -> client: the tombstoned payload rows whose blobs the worker must delete.
+message GetTombstonedPayloadsResponse {
+    repeated TombstonedPayload payloads = 1;
+}
+
+// client -> server: acks for payloads whose blobs the worker has deleted.
+message AckPurgedPayloadsRequest {
+    repeated PayloadPurgeAck acks = 1;
+}
+
+// server -> client: response acknowledging the hard-deletes.
+message AckPurgedPayloadsResponse {
 }
 
 message GetWorkItemsRequest {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -885,49 +885,58 @@ enum LargePayloadPurgeDisposition {
 // number of distinct causes, because `storageErrorCode` already carries the specific storage status.
 // Values must never carry a token or raw exception text: a token exposes the storage account,
 // container, and blob path.
+//
+// Reason and disposition are orthogonal and there is no fixed mapping between them. A reason says
+// what the worker found; a disposition says whether trying again can change it. Most reasons occur
+// with exactly one disposition, but TOKEN_NOT_PURGEABLE deliberately occurs with two. Do not assert
+// a reason-to-disposition mapping anywhere.
 enum LargePayloadPurgeReason {
     LARGE_PAYLOAD_PURGE_REASON_UNSPECIFIED = 0;
 
-    // --- Reported with DELETED ---
-
-    // The blob was deleted by this attempt, reclaiming its bytes.
+    // Reported with DELETED. The blob was deleted by this attempt, reclaiming its bytes.
     LARGE_PAYLOAD_PURGE_REASON_BLOB_DELETED = 1;
 
-    // The blob was already absent, so deletion was a no-op and no bytes were reclaimed by this
-    // attempt. Deletion is idempotent, so this is a success rather than a failure. Reported
-    // separately from BLOB_DELETED because a high rate of it indicates duplicate tombstones.
+    // Reported with DELETED. The blob was already absent, so deletion was a no-op and no bytes were
+    // reclaimed by this attempt. Deletion is idempotent, so this is a success rather than a failure.
+    // Reported separately from BLOB_DELETED because a high rate of it indicates duplicate tombstones.
     LARGE_PAYLOAD_PURGE_REASON_BLOB_ALREADY_ABSENT = 2;
 
-    // The blob was left in place because it did not carry the payload store's ownership marker,
-    // meaning the store did not write it. The token text merely matched the v2 grammar; the payload
-    // column is customer-writable, so matching text is not proof of ownership. This is an expected
-    // outcome rather than a defect. The tombstone is still resolved, because a blob the store does
-    // not own will never become deletable and retrying forever would leak the row. Reported
-    // separately from BLOB_DELETED so that "resolved without reclaiming bytes" stays countable.
+    // Reported with DELETED. The blob was left in place because it did not carry the payload store's
+    // ownership marker, meaning the store did not write it. The token text merely matched the v2
+    // grammar; the payload column is customer-writable, so matching text is not proof of ownership.
+    // This is an expected outcome rather than a defect. The tombstone is still resolved, because a
+    // blob the store does not own will never become deletable and retrying forever would leak the
+    // row. Reported separately so that "resolved without reclaiming bytes" stays countable.
     LARGE_PAYLOAD_PURGE_REASON_BLOB_NOT_STORE_OWNED = 3;
 
-    // --- Reported with RETRY ---
-
-    // The deletion failed against storage: network failure, timeout, outage, throttling, an
-    // unreachable account, or an authorization failure. All of these are reconfigurable or
-    // self-healing, and they are not subdivided here because `storageErrorCode` already carries the
-    // specific status for diagnostics. Subdividing would encode the same fact twice.
+    // Reported with RETRY. The deletion failed against storage: network failure, timeout, outage,
+    // throttling, an unreachable account, or an authorization failure. All of these are
+    // reconfigurable or self-healing, and they are not subdivided here because `storageErrorCode`
+    // already carries the specific status. Subdividing would encode the same fact twice.
     LARGE_PAYLOAD_PURGE_REASON_STORAGE_FAILURE = 10;
 
-    // The registered payload store does not implement deletion. Every payload fails the same way,
-    // so this is a deployment-wide condition rather than a per-row one, and it is kept recoverable
-    // until an operator registers a store that can delete. `storageErrorCode` is empty because
-    // storage was never contacted, which is why this cannot be folded into STORAGE_FAILURE.
+    // Reported with RETRY. The registered payload store does not implement deletion. Every payload
+    // fails the same way, so this is a deployment-wide condition rather than a per-row one, and it
+    // is kept recoverable until an operator registers a store that can delete. `storageErrorCode` is
+    // empty because storage was never contacted, which is why this cannot be folded into
+    // STORAGE_FAILURE.
     LARGE_PAYLOAD_PURGE_REASON_STORE_CANNOT_DELETE = 11;
 
-    // --- Reported with QUARANTINED ---
-
-    // The token cannot be acted on and no retry can change that: its body does not parse, it names
-    // a version this worker does not support, or storage rejected it as permanently invalid. The
-    // producer and consumer of this token are both controlled by the SDK and backend, so reaching
-    // this state indicates a producer, corruption, or compatibility bug and the evidence is
-    // preserved for investigation rather than discarded. `storageErrorCode` distinguishes the
-    // storage-rejected case, where it is populated, from the parse cases, where it is empty.
+    // The worker could not act on the token. This reason is reported with TWO dispositions, and a
+    // consumer must not assume either one.
+    //
+    // Reported with QUARANTINED when the token can never become usable: its body does not parse, it
+    // is a legacy v1 token, or storage rejected a well-formed token as permanently invalid. The SDK
+    // and backend control both sides of this protocol, so reaching that state indicates a producer,
+    // corruption, or compatibility bug, and the evidence is preserved rather than discarded.
+    //
+    // Reported with RETRY in exactly one case: the token names a version this worker does not
+    // understand. Nothing is wrong with that token, since a newer worker can read it, so an SDK
+    // upgrade resolves it. The asymmetry is deliberate: quarantining it would be permanent and
+    // unrecoverable, whereas a retry that never succeeds only leaves the row idle and visible.
+    //
+    // `storageErrorCode` distinguishes the storage-rejected case, where it is populated, from the
+    // parse and unknown-version cases, where it is empty.
     LARGE_PAYLOAD_PURGE_REASON_TOKEN_NOT_PURGEABLE = 20;
 }
 

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -786,6 +786,12 @@ service TaskHubSidecarService {
     rpc PurgeInstances(PurgeInstancesRequest) returns (PurgeInstancesResponse);
 
     rpc GetWorkItems(GetWorkItemsRequest) returns (stream WorkItem);
+
+    // Streams tombstoned large-payload blob tokens to a connected worker for deletion; the worker
+    // acks each deleted blob so the backend can hard-delete the corresponding row. Idempotent and
+    // safe with multiple worker replicas (unacked rows stay tombstoned and are re-streamed).
+    rpc PurgeExternalPayloads(stream PayloadPurged) returns (stream TombstonedPayload);
+
     rpc CompleteActivityTask(ActivityResponse) returns (CompleteTaskResponse);
     rpc CompleteOrchestratorTask(OrchestratorResponse) returns (CompleteTaskResponse);
     rpc CompleteEntityTask(EntityBatchResult) returns (CompleteTaskResponse);
@@ -823,6 +829,21 @@ service TaskHubSidecarService {
     // "Skip" graceful termination of orchestrations by immediately changing their status in storage to "terminated".
     // Note that a maximum of 500 orchestrations can be terminated at a time using this method.
     rpc SkipGracefulOrchestrationTerminations(SkipGracefulOrchestrationTerminationsRequest) returns (SkipGracefulOrchestrationTerminationsResponse);
+}
+
+// server -> client: a tombstoned payload row whose blob the worker must delete.
+message TombstonedPayload {
+    int32  partitionId = 1;
+    int64  instanceKey = 2;
+    int64  payloadId   = 3;
+    string token       = 4;   // e.g. "blob:v1:<container>:<blobName>"
+}
+
+// client -> server: ack sent after the worker deletes the blob; backend hard-deletes that row.
+message PayloadPurged {
+    int32 partitionId = 1;
+    int64 instanceKey = 2;
+    int64 payloadId   = 3;
 }
 
 message GetWorkItemsRequest {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -872,72 +872,12 @@ enum LargePayloadPurgeDisposition {
     // The failure may self-heal, so the row stays pending and the backend sets the next attempt.
     LARGE_PAYLOAD_PURGE_DISPOSITION_RETRY = 2;
 
-    // A deterministic failure or protocol violation that retrying can never fix. The backend
-    // preserves the evidence, alerts, and stops automatic retries.
+    // A deterministic failure or protocol violation that retrying can never fix. The row leaves the
+    // polling set but is never deleted or expired: it keeps the token, which after the payload row is
+    // gone is the only durable record of the blob, so discarding it would orphan the blob silently.
+    // Resolving a quarantined row is a deliberate operator action. Why it failed is not recorded here
+    // and is not meant to be; that detail lives in the worker's telemetry at full fidelity.
     LARGE_PAYLOAD_PURGE_DISPOSITION_QUARANTINED = 3;
-}
-
-// Why a row received its disposition. Diagnostic only: the backend acts on `disposition` alone and
-// never branches on this value, so it exists to make a stuck or non-reclaiming ledger explainable
-// without access to worker logs, which run in the customer's process.
-//
-// Deliberately coarse. Granularity matches the number of distinct operator responses, not the
-// number of distinct causes, because `storageErrorCode` already carries the specific storage status.
-// Values must never carry a token or raw exception text: a token exposes the storage account,
-// container, and blob path.
-//
-// Reason and disposition are orthogonal and there is no fixed mapping between them. A reason says
-// what the worker found; a disposition says whether trying again can change it. Most reasons occur
-// with exactly one disposition, but TOKEN_NOT_PURGEABLE deliberately occurs with two. Do not assert
-// a reason-to-disposition mapping anywhere.
-enum LargePayloadPurgeReason {
-    LARGE_PAYLOAD_PURGE_REASON_UNSPECIFIED = 0;
-
-    // Reported with DELETED. The blob was deleted by this attempt, reclaiming its bytes.
-    LARGE_PAYLOAD_PURGE_REASON_BLOB_DELETED = 1;
-
-    // Reported with DELETED. The blob was already absent, so deletion was a no-op and no bytes were
-    // reclaimed by this attempt. Deletion is idempotent, so this is a success rather than a failure.
-    // Reported separately from BLOB_DELETED because a high rate of it indicates duplicate tombstones.
-    LARGE_PAYLOAD_PURGE_REASON_BLOB_ALREADY_ABSENT = 2;
-
-    // Reported with DELETED. The blob was left in place because it did not carry the payload store's
-    // ownership marker, meaning the store did not write it. The token text merely matched the v2
-    // grammar; the payload column is customer-writable, so matching text is not proof of ownership.
-    // This is an expected outcome rather than a defect. The tombstone is still resolved, because a
-    // blob the store does not own will never become deletable and retrying forever would leak the
-    // row. Reported separately so that "resolved without reclaiming bytes" stays countable.
-    LARGE_PAYLOAD_PURGE_REASON_BLOB_NOT_STORE_OWNED = 3;
-
-    // Reported with RETRY. The deletion failed against storage: network failure, timeout, outage,
-    // throttling, an unreachable account, or an authorization failure. All of these are
-    // reconfigurable or self-healing, and they are not subdivided here because `storageErrorCode`
-    // already carries the specific status. Subdividing would encode the same fact twice.
-    LARGE_PAYLOAD_PURGE_REASON_STORAGE_FAILURE = 10;
-
-    // Reported with RETRY. The registered payload store does not implement deletion. Every payload
-    // fails the same way, so this is a deployment-wide condition rather than a per-row one, and it
-    // is kept recoverable until an operator registers a store that can delete. `storageErrorCode` is
-    // empty because storage was never contacted, which is why this cannot be folded into
-    // STORAGE_FAILURE.
-    LARGE_PAYLOAD_PURGE_REASON_STORE_CANNOT_DELETE = 11;
-
-    // The worker could not act on the token. This reason is reported with TWO dispositions, and a
-    // consumer must not assume either one.
-    //
-    // Reported with QUARANTINED when the token can never become usable: its body does not parse, it
-    // is a legacy v1 token, or storage rejected a well-formed token as permanently invalid. The SDK
-    // and backend control both sides of this protocol, so reaching that state indicates a producer,
-    // corruption, or compatibility bug, and the evidence is preserved rather than discarded.
-    //
-    // Reported with RETRY in exactly one case: the token names a version this worker does not
-    // understand. Nothing is wrong with that token, since a newer worker can read it, so an SDK
-    // upgrade resolves it. The asymmetry is deliberate: quarantining it would be permanent and
-    // unrecoverable, whereas a retry that never succeeds only leaves the row idle and visible.
-    //
-    // `storageErrorCode` distinguishes the storage-rejected case, where it is populated, from the
-    // parse and unknown-version cases, where it is empty.
-    LARGE_PAYLOAD_PURGE_REASON_TOKEN_NOT_PURGEABLE = 20;
 }
 
 // client -> server: the outcome of exactly one tombstoned row.
@@ -950,12 +890,11 @@ message LargePayloadPurgeResult {
     // Echoed unmodified from the fetched tombstone; used as a compare-and-swap guard.
     int64 revision = 4;
 
+    // The only field the backend acts on. Deliberately the only outcome field on this message:
+    // anything finer would be write-only. Failure detail stays in the worker's own telemetry, which
+    // holds the full exception rather than a lossy classification, and a row is correlated to it by
+    // (partitionId, instanceKey, payloadId) plus the ledger's LastAttemptAt.
     LargePayloadPurgeDisposition disposition = 5;
-    LargePayloadPurgeReason reason = 6;
-
-    // Optional bounded, sanitized storage status or error code for diagnostics
-    // (for example "BlobNotFound" or "409"). Must never contain a token or raw exception text.
-    string storageErrorCode = 7;
 }
 
 // client -> server: request up to `limit` due tombstones for the caller's task hub.

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -793,9 +793,10 @@ service TaskHubSidecarService {
     // pending until its outcome is reported, so this is safe under retries and duplicate callers.
     rpc GetLargePayloadTombstones(GetLargePayloadTombstonesRequest) returns (GetLargePayloadTombstonesResponse);
 
-    // Reports the outcome of each attempted blob deletion. The backend owns retry scheduling: it
-    // deletes rows reported as DELETED, reschedules RETRY with a reason-appropriate next attempt,
-    // and moves QUARANTINED rows out of the active fetch while preserving their evidence.
+    // Reports the outcome of each attempted blob deletion. The backend owns retry scheduling and
+    // branches solely on `disposition`: it deletes rows reported as DELETED, reschedules RETRY on
+    // its own backoff, and moves QUARANTINED rows out of the active fetch while preserving their
+    // evidence. The worker never computes a retry delay.
     rpc ReportLargePayloadPurgeResults(ReportLargePayloadPurgeResultsRequest) returns (ReportLargePayloadPurgeResultsResponse);
 
     rpc CompleteActivityTask(ActivityResponse) returns (CompleteTaskResponse);
@@ -846,7 +847,7 @@ message LargePayloadTombstone {
     // A self-describing SDK v2 token: "blob:v2:{fullBlobUrl}".
     // Legacy v1 tokens are never tombstoned: v1 carries a container name but not the storage
     // account, so a delete against the configured account cannot be verified. The backend
-    // hard-deletes v1 payload rows instead (design §8).
+    // hard-deletes v1 payload rows instead.
     string token = 4;
 
     // Optimistic-concurrency guard. The worker echoes this value back unmodified in the result so
@@ -856,11 +857,16 @@ message LargePayloadTombstone {
 
 // The outcome of a single blob deletion attempt. The split is by whether a failure can self-heal.
 enum LargePayloadPurgeDisposition {
+    // Required: proto3 reserves 0 as the first value, and scalars have no field presence, so an
+    // unset field arrives as 0. Keeping 0 meaningless is load-bearing here: if 0 meant DELETED, a
+    // client that failed to set this field would make the backend delete tombstones and orphan the
+    // blobs permanently. The backend must reject a result carrying this value.
     LARGE_PAYLOAD_PURGE_DISPOSITION_UNSPECIFIED = 0;
 
-    // Terminal success. The blob was deleted, was already absent, or was deliberately left in
-    // place because it is not owned by the payload store (design §5.5). The backend deletes the
-    // tombstone in all three cases.
+    // Terminal success: the tombstone is resolved and the backend deletes it. Covers the blob being
+    // deleted, the blob already being absent, and the blob being deliberately left in place because
+    // the payload store does not own it. All three are terminal because none of them can be
+    // improved by trying again.
     LARGE_PAYLOAD_PURGE_DISPOSITION_DELETED = 1;
 
     // The failure may self-heal, so the row stays pending and the backend sets the next attempt.
@@ -871,59 +877,58 @@ enum LargePayloadPurgeDisposition {
     LARGE_PAYLOAD_PURGE_DISPOSITION_QUARANTINED = 3;
 }
 
-// A stable, bounded reason for a disposition. Never carries a token or raw exception text
-// (design §7: tokens expose storage account, container, and blob path).
+// Why a row received its disposition. Diagnostic only: the backend acts on `disposition` alone and
+// never branches on this value, so it exists to make a stuck or non-reclaiming ledger explainable
+// without access to worker logs, which run in the customer's process.
+//
+// Deliberately coarse. Granularity matches the number of distinct operator responses, not the
+// number of distinct causes, because `storageErrorCode` already carries the specific storage status.
+// Values must never carry a token or raw exception text: a token exposes the storage account,
+// container, and blob path.
 enum LargePayloadPurgeReason {
     LARGE_PAYLOAD_PURGE_REASON_UNSPECIFIED = 0;
 
     // --- Reported with DELETED ---
 
-    // The blob was deleted by this attempt.
+    // The blob was deleted by this attempt, reclaiming its bytes.
     LARGE_PAYLOAD_PURGE_REASON_BLOB_DELETED = 1;
 
-    // The blob was already absent. Deletion is idempotent, so this is a success.
+    // The blob was already absent, so deletion was a no-op and no bytes were reclaimed by this
+    // attempt. Deletion is idempotent, so this is a success rather than a failure. Reported
+    // separately from BLOB_DELETED because a high rate of it indicates duplicate tombstones.
     LARGE_PAYLOAD_PURGE_REASON_BLOB_ALREADY_ABSENT = 2;
 
-    // The blob did not carry the payload store's ownership marker, so it was left untouched
-    // (design §5.5). This is an expected outcome, not a defect: the token text merely matched the
-    // v2 grammar. The tombstone is still resolved because the blob is not the store's to delete.
+    // The blob was left in place because it did not carry the payload store's ownership marker,
+    // meaning the store did not write it. The token text merely matched the v2 grammar; the payload
+    // column is customer-writable, so matching text is not proof of ownership. This is an expected
+    // outcome rather than a defect. The tombstone is still resolved, because a blob the store does
+    // not own will never become deletable and retrying forever would leak the row. Reported
+    // separately from BLOB_DELETED so that "resolved without reclaiming bytes" stays countable.
     LARGE_PAYLOAD_PURGE_REASON_BLOB_NOT_STORE_OWNED = 3;
 
     // --- Reported with RETRY ---
 
-    // Network failure, timeout, storage outage, throttling, or a 5xx response.
-    LARGE_PAYLOAD_PURGE_REASON_TRANSIENT_STORAGE_FAILURE = 10;
+    // The deletion failed against storage: network failure, timeout, outage, throttling, an
+    // unreachable account, or an authorization failure. All of these are reconfigurable or
+    // self-healing, and they are not subdivided here because `storageErrorCode` already carries the
+    // specific status for diagnostics. Subdividing would encode the same fact twice.
+    LARGE_PAYLOAD_PURGE_REASON_STORAGE_FAILURE = 10;
 
-    // The registered payload store does not implement deletion. Every payload would fail the same
-    // way, so the work is kept recoverable until an operator registers a store that can delete.
+    // The registered payload store does not implement deletion. Every payload fails the same way,
+    // so this is a deployment-wide condition rather than a per-row one, and it is kept recoverable
+    // until an operator registers a store that can delete. `storageErrorCode` is empty because
+    // storage was never contacted, which is why this cannot be folded into STORAGE_FAILURE.
     LARGE_PAYLOAD_PURGE_REASON_STORE_CANNOT_DELETE = 11;
-
-    // The token is well formed but points at a storage account this worker's credential cannot
-    // reach. Recoverable after a configuration or credential change.
-    LARGE_PAYLOAD_PURGE_REASON_STORAGE_ACCOUNT_UNREACHABLE = 12;
-
-    // The token uses a recognized-but-newer version prefix this worker does not understand.
-    // Recoverable after an SDK upgrade, so it earns a long defer rather than quarantine.
-    LARGE_PAYLOAD_PURGE_REASON_UNSUPPORTED_TOKEN_VERSION = 13;
-
-    // Authorization failed in a way that may be transient or reconfigurable (401/403).
-    LARGE_PAYLOAD_PURGE_REASON_STORAGE_AUTHORIZATION_FAILED = 14;
 
     // --- Reported with QUARANTINED ---
 
-    // The token carries a known version prefix but its body does not parse. Because the SDK and
-    // backend control both sides of the protocol, this indicates a producer, corruption, or
-    // compatibility bug.
-    LARGE_PAYLOAD_PURGE_REASON_MALFORMED_TOKEN = 20;
-
-    // Storage rejected a request generated from a well-formed token as permanently invalid
-    // (HTTP 400, e.g. InvalidUri / InvalidResourceName). Retrying can never succeed.
-    LARGE_PAYLOAD_PURGE_REASON_INVALID_STORAGE_REQUEST = 21;
-
-    // A legacy v1 token reached the worker. This is an invariant violation, because the backend
-    // excludes v1 at insertion time. It cannot be safely deleted (no storage account in the token)
-    // and cannot be fixed by retrying, so the evidence is preserved instead (design §6).
-    LARGE_PAYLOAD_PURGE_REASON_LEGACY_V1_TOKEN = 22;
+    // The token cannot be acted on and no retry can change that: its body does not parse, it names
+    // a version this worker does not support, or storage rejected it as permanently invalid. The
+    // producer and consumer of this token are both controlled by the SDK and backend, so reaching
+    // this state indicates a producer, corruption, or compatibility bug and the evidence is
+    // preserved for investigation rather than discarded. `storageErrorCode` distinguishes the
+    // storage-rejected case, where it is populated, from the parse cases, where it is empty.
+    LARGE_PAYLOAD_PURGE_REASON_TOKEN_NOT_PURGEABLE = 20;
 }
 
 // client -> server: the outcome of exactly one tombstoned row.

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -893,7 +893,7 @@ message LargePayloadPurgeResult {
     // The only field the backend acts on. Deliberately the only outcome field on this message:
     // anything finer would be write-only. Failure detail stays in the worker's own telemetry, which
     // holds the full exception rather than a lossy classification, and a row is correlated to it by
-    // (partitionId, instanceKey, payloadId) plus the ledger's LastAttemptAt.
+    // (partitionId, instanceKey, payloadId).
     LargePayloadPurgeDisposition disposition = 5;
 }
 

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -787,15 +787,16 @@ service TaskHubSidecarService {
 
     rpc GetWorkItems(GetWorkItemsRequest) returns (stream WorkItem);
 
-    // Fetches up to `limit` tombstoned large-payload rows whose external blobs the worker must
-    // delete. The worker (which has storage credentials) deletes each blob, then calls
-    // AckPurgedPayloads so the backend can hard-delete those rows. Idempotent and safe under
-    // retries/duplicate callers (unacked rows stay tombstoned and are returned again).
-    rpc GetTombstonedPayloads(GetTombstonedPayloadsRequest) returns (GetTombstonedPayloadsResponse);
+    // Returns a bounded, deterministically ordered batch of due large-payload tombstones whose
+    // external blobs the worker must delete. Scoped to the caller's authenticated task hub.
+    // Only rows that are pending and whose next attempt time has arrived are returned; a row stays
+    // pending until its outcome is reported, so this is safe under retries and duplicate callers.
+    rpc GetLargePayloadTombstones(GetLargePayloadTombstonesRequest) returns (GetLargePayloadTombstonesResponse);
 
-    // Acks tombstoned payloads whose external blobs the worker has deleted; the backend hard-deletes
-    // the corresponding rows. Idempotent and safe under retries/duplicate callers.
-    rpc AckPurgedPayloads(AckPurgedPayloadsRequest) returns (AckPurgedPayloadsResponse);
+    // Reports the outcome of each attempted blob deletion. The backend owns retry scheduling: it
+    // deletes rows reported as DELETED, reschedules RETRY with a reason-appropriate next attempt,
+    // and moves QUARANTINED rows out of the active fetch while preserving their evidence.
+    rpc ReportLargePayloadPurgeResults(ReportLargePayloadPurgeResultsRequest) returns (ReportLargePayloadPurgeResultsResponse);
 
     rpc CompleteActivityTask(ActivityResponse) returns (CompleteTaskResponse);
     rpc CompleteOrchestratorTask(OrchestratorResponse) returns (CompleteTaskResponse);
@@ -836,38 +837,131 @@ service TaskHubSidecarService {
     rpc SkipGracefulOrchestrationTerminations(SkipGracefulOrchestrationTerminationsRequest) returns (SkipGracefulOrchestrationTerminationsResponse);
 }
 
-// server -> client: a tombstoned payload row whose blob the worker must delete.
-message TombstonedPayload {
-    int32  partitionId = 1;
-    int64  instanceKey = 2;
-    int64  payloadId   = 3;
-    string token       = 4;   // e.g. "blob:v1:<container>:<blobName>"
-}
-
-// client -> server: ack sent after the worker deletes the blob; backend hard-deletes that row.
-message PayloadPurgeAck {
+// server -> client: one tombstoned large-payload row whose external blob the worker must delete.
+message LargePayloadTombstone {
     int32 partitionId = 1;
     int64 instanceKey = 2;
-    int64 payloadId   = 3;
+    int64 payloadId = 3;
+
+    // A self-describing SDK v2 token: "blob:v2:{fullBlobUrl}".
+    // Legacy v1 tokens are never tombstoned: v1 carries a container name but not the storage
+    // account, so a delete against the configured account cannot be verified. The backend
+    // hard-deletes v1 payload rows instead (design §8).
+    string token = 4;
+
+    // Optimistic-concurrency guard. The worker echoes this value back unmodified in the result so
+    // the backend can reject duplicate or stale reports without taking a per-row lease.
+    int64 revision = 5;
 }
 
-// client -> server: request up to `limit` tombstoned payload rows to purge.
-message GetTombstonedPayloadsRequest {
+// The outcome of a single blob deletion attempt. The split is by whether a failure can self-heal.
+enum LargePayloadPurgeDisposition {
+    LARGE_PAYLOAD_PURGE_DISPOSITION_UNSPECIFIED = 0;
+
+    // Terminal success. The blob was deleted, was already absent, or was deliberately left in
+    // place because it is not owned by the payload store (design §5.5). The backend deletes the
+    // tombstone in all three cases.
+    LARGE_PAYLOAD_PURGE_DISPOSITION_DELETED = 1;
+
+    // The failure may self-heal, so the row stays pending and the backend sets the next attempt.
+    LARGE_PAYLOAD_PURGE_DISPOSITION_RETRY = 2;
+
+    // A deterministic failure or protocol violation that retrying can never fix. The backend
+    // preserves the evidence, alerts, and stops automatic retries.
+    LARGE_PAYLOAD_PURGE_DISPOSITION_QUARANTINED = 3;
+}
+
+// A stable, bounded reason for a disposition. Never carries a token or raw exception text
+// (design §7: tokens expose storage account, container, and blob path).
+enum LargePayloadPurgeReason {
+    LARGE_PAYLOAD_PURGE_REASON_UNSPECIFIED = 0;
+
+    // --- Reported with DELETED ---
+
+    // The blob was deleted by this attempt.
+    LARGE_PAYLOAD_PURGE_REASON_BLOB_DELETED = 1;
+
+    // The blob was already absent. Deletion is idempotent, so this is a success.
+    LARGE_PAYLOAD_PURGE_REASON_BLOB_ALREADY_ABSENT = 2;
+
+    // The blob did not carry the payload store's ownership marker, so it was left untouched
+    // (design §5.5). This is an expected outcome, not a defect: the token text merely matched the
+    // v2 grammar. The tombstone is still resolved because the blob is not the store's to delete.
+    LARGE_PAYLOAD_PURGE_REASON_BLOB_NOT_STORE_OWNED = 3;
+
+    // --- Reported with RETRY ---
+
+    // Network failure, timeout, storage outage, throttling, or a 5xx response.
+    LARGE_PAYLOAD_PURGE_REASON_TRANSIENT_STORAGE_FAILURE = 10;
+
+    // The registered payload store does not implement deletion. Every payload would fail the same
+    // way, so the work is kept recoverable until an operator registers a store that can delete.
+    LARGE_PAYLOAD_PURGE_REASON_STORE_CANNOT_DELETE = 11;
+
+    // The token is well formed but points at a storage account this worker's credential cannot
+    // reach. Recoverable after a configuration or credential change.
+    LARGE_PAYLOAD_PURGE_REASON_STORAGE_ACCOUNT_UNREACHABLE = 12;
+
+    // The token uses a recognized-but-newer version prefix this worker does not understand.
+    // Recoverable after an SDK upgrade, so it earns a long defer rather than quarantine.
+    LARGE_PAYLOAD_PURGE_REASON_UNSUPPORTED_TOKEN_VERSION = 13;
+
+    // Authorization failed in a way that may be transient or reconfigurable (401/403).
+    LARGE_PAYLOAD_PURGE_REASON_STORAGE_AUTHORIZATION_FAILED = 14;
+
+    // --- Reported with QUARANTINED ---
+
+    // The token carries a known version prefix but its body does not parse. Because the SDK and
+    // backend control both sides of the protocol, this indicates a producer, corruption, or
+    // compatibility bug.
+    LARGE_PAYLOAD_PURGE_REASON_MALFORMED_TOKEN = 20;
+
+    // Storage rejected a request generated from a well-formed token as permanently invalid
+    // (HTTP 400, e.g. InvalidUri / InvalidResourceName). Retrying can never succeed.
+    LARGE_PAYLOAD_PURGE_REASON_INVALID_STORAGE_REQUEST = 21;
+
+    // A legacy v1 token reached the worker. This is an invariant violation, because the backend
+    // excludes v1 at insertion time. It cannot be safely deleted (no storage account in the token)
+    // and cannot be fixed by retrying, so the evidence is preserved instead (design §6).
+    LARGE_PAYLOAD_PURGE_REASON_LEGACY_V1_TOKEN = 22;
+}
+
+// client -> server: the outcome of exactly one tombstoned row.
+message LargePayloadPurgeResult {
+    // Row identity, echoed from the corresponding LargePayloadTombstone.
+    int32 partitionId = 1;
+    int64 instanceKey = 2;
+    int64 payloadId = 3;
+
+    // Echoed unmodified from the fetched tombstone; used as a compare-and-swap guard.
+    int64 revision = 4;
+
+    LargePayloadPurgeDisposition disposition = 5;
+    LargePayloadPurgeReason reason = 6;
+
+    // Optional bounded, sanitized storage status or error code for diagnostics
+    // (for example "BlobNotFound" or "409"). Must never contain a token or raw exception text.
+    string storageErrorCode = 7;
+}
+
+// client -> server: request up to `limit` due tombstones for the caller's task hub.
+message GetLargePayloadTombstonesRequest {
+    // The maximum number of rows to return. The service clamps this to its own maximum.
     int32 limit = 1;
 }
 
-// server -> client: the tombstoned payload rows whose blobs the worker must delete.
-message GetTombstonedPayloadsResponse {
-    repeated TombstonedPayload payloads = 1;
+// server -> client: the due tombstones whose blobs the worker must delete.
+message GetLargePayloadTombstonesResponse {
+    repeated LargePayloadTombstone tombstones = 1;
 }
 
-// client -> server: acks for payloads whose blobs the worker has deleted.
-message AckPurgedPayloadsRequest {
-    repeated PayloadPurgeAck acks = 1;
+// client -> server: a bounded batch of purge outcomes.
+message ReportLargePayloadPurgeResultsRequest {
+    repeated LargePayloadPurgeResult results = 1;
 }
 
-// server -> client: response acknowledging the hard-deletes.
-message AckPurgedPayloadsResponse {
+// server -> client: acknowledgement that the reported outcomes were recorded.
+message ReportLargePayloadPurgeResultsResponse {
 }
 
 message GetWorkItemsRequest {
@@ -877,6 +971,16 @@ message GetWorkItemsRequest {
 
     repeated WorkerCapability capabilities = 10;
     WorkItemFilters workItemFilters = 11;
+
+    // Task-hub scoped opt-in for large-payload blob auto-purge.
+    //
+    // This is a setting, not a WorkerCapability: WORKER_CAPABILITY_LARGE_PAYLOADS means a worker
+    // *can resolve* externalized payloads, not that the customer opted into *deleting* them.
+    // A capability list is presence-only and cannot express an explicit false, so a three-state
+    // wrapper is used instead:
+    //   absent      -> the worker has no opinion (older SDK); the persisted setting is unchanged.
+    //   true/false  -> an explicit customer choice; persisted only when the value actually differs.
+    google.protobuf.BoolValue large_payload_auto_purge_enabled = 12;
 }
 
 enum WorkerCapability {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -790,7 +790,7 @@ service TaskHubSidecarService {
     // Streams tombstoned large-payload blob tokens to a connected worker for deletion; the worker
     // acks each deleted blob so the backend can hard-delete the corresponding row. Idempotent and
     // safe with multiple worker replicas (unacked rows stay tombstoned and are re-streamed).
-    rpc PurgeExternalPayloads(stream PayloadPurged) returns (stream TombstonedPayload);
+    rpc PurgeExternalPayloads(stream PayloadPurgeAck) returns (stream TombstonedPayload);
 
     rpc CompleteActivityTask(ActivityResponse) returns (CompleteTaskResponse);
     rpc CompleteOrchestratorTask(OrchestratorResponse) returns (CompleteTaskResponse);
@@ -840,7 +840,7 @@ message TombstonedPayload {
 }
 
 // client -> server: ack sent after the worker deletes the blob; backend hard-deletes that row.
-message PayloadPurged {
+message PayloadPurgeAck {
     int32 partitionId = 1;
     int64 instanceKey = 2;
     int64 payloadId   = 3;


### PR DESCRIPTION
## Summary

Adds the **authoritative** proto contract for the large-payload blob auto-purge feature. This is the source-of-truth definition that the other PRs vendor locally and re-sync from once this merges:
- SDK: microsoft/durabletask-dotnet #758
- DTS backend: AAPT-DTMB #16368738

The definitions here are byte-identical to the canonical contract shared with durabletask-dotnet #758.

## Context

When an orchestration payload exceeds a threshold it is externalized to Azure Blob Storage and a token is persisted in the backend's SQL `Payloads.Text` column instead of the payload bytes. Purging the orchestration removes the SQL state, but the backend cannot delete the blob because it does not hold the customer's storage credentials, so the blob is orphaned.

**Fix:** the backend keeps the durable cleanup work and hands it to a worker that *does* have storage credentials. The backend records a tombstone for each externalized payload leaving live state; the worker fetches a bounded batch of due tombstones, deletes each blob, and reports the outcome of every attempt. The backend then resolves, reschedules, or quarantines each row.

## Change

Edits only `protos/orchestrator_service.proto`. Nothing is added to the backend-facing service: the backend serves both services on one endpoint and the worker already reaches `TaskHubSidecarService` there, so authorization stays identical to the existing worker stream.

**Opt-in on the existing handshake** — `google.protobuf.BoolValue large_payload_auto_purge_enabled = 12` on the existing `GetWorkItemsRequest`. `GetWorkItems` is already task-hub scoped and authenticated, so the setting binds to that task hub without a new RPC. This is a *setting*, not a `WorkerCapability`: `WORKER_CAPABILITY_LARGE_PAYLOADS` means a worker *can resolve* externalized payloads, not that the customer opted into *deleting* them. A `repeated` capability enum is presence-only and could never express an explicit `false`, so it could not turn the feature off.

**Two bounded unary RPCs**, placed immediately after `GetWorkItems`:

| RPC | Purpose |
|---|---|
| `GetLargePayloadTombstones` | Hand the worker a bounded, deterministically ordered batch of *due* tombstones |
| `ReportLargePayloadPurgeResults` | Record the outcome of each attempt; the **backend** owns retry scheduling |

**Dispositions** — exactly three: `DELETED`, `RETRY`, `QUARANTINED`. The split is by whether a failure can self-heal. There is deliberately no `Discarded`: it was success-shaped and destroyed evidence.

**No reason or error-code fields** - `disposition` is the only outcome field on `LargePayloadPurgeResult`. Earlier revisions of this PR also carried a `LargePayloadPurgeReason` enum and a `storageErrorCode` string; both were removed because they were write-only. The backend persists them, but no `SELECT`, `WHERE`, API, or alert reads either one, and every backend action branches on `disposition` alone. Failure detail already lives in the worker's telemetry at full exception fidelity, where a row is correlated by `(partitionId, instanceKey, payloadId)`, so the fields were a lossy copy nobody queried. No `reserved` statements were added: these messages have never shipped in a release, so no deployed peer has ever seen field `6` or `7`. `disposition` stays at field `5` rather than being renumbered to close the gap.

**`revision`** — carried on both the tombstone and the result as a compare-and-swap guard, so duplicate or stale reports are no-ops without a per-row lease.

**Tokens** — documented as `blob:v2:{fullBlobUrl}`. Legacy `v1` tokens are never tombstoned: `v1` carries a container name but not the storage account, so a delete cannot be verified against the configured account. The backend hard-deletes `v1` payload rows instead, and a `v1` token reaching the worker is an invariant violation that is quarantined rather than discarded.

## Supersedes the earlier shape

This replaces the previous draft contract, which is fully removed rather than extended:
- `GetTombstonedPayloads` / `AckPurgedPayloads` → renamed and reshaped. The old pair was a fetch plus a bare identity-only ack, which cannot distinguish success from an unfixable failure and left retry scheduling ambiguous.
- Messages `TombstonedPayload`, `PayloadPurgeAck`, `GetTombstonedPayloadsRequest`, `GetTombstonedPayloadsResponse`, `AckPurgedPayloadsRequest`, `AckPurgedPayloadsResponse` → removed.
- `protos/backend_service.proto` → reverted; it is now byte-identical to `main`.

Because none of the related PRs has merged, this is not a compatibility constraint.

## Verification

- `git diff origin/main -- protos/backend_service.proto` is empty.
- Field `12` was previously unused in `GetWorkItemsRequest` (which used `1, 2, 3, 10, 11`); no field number collides.
- `google/protobuf/wrappers.proto` was already imported; no duplicate import added.
- All three protos compile with `protoc` (no errors; the only warnings are pre-existing unused imports in `backend_service.proto`). Descriptor introspection confirms the field numbers, RPC wiring, and enum values, and that no removed symbol survives.

No language stubs were regenerated: this is a proto-only repo (SDKs consume the protos via git submodule and generate code at build time into gitignored `build/` dirs; no generated stubs are checked in).

