### PR TITLE
Add external_payload_store_uri to GetWorkItemsRequest

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -832,6 +832,12 @@ message GetWorkItemsRequest {
 
     repeated WorkerCapability capabilities = 10;
     WorkItemFilters workItemFilters = 11;
+
+    // Non-secret base URI of the external payload store (e.g. "https://<account>.blob.core.windows.net/")
+    // where this worker externalizes large payloads. Reported so the backend can surface it to dashboards,
+    // which read the referenced blobs directly using the signed-in user's own credentials. Empty when the
+    // worker has no external payload store configured. Never contains a secret, SAS, or account key.
+    string external_payload_store_uri = 12 [json_name = "externalPayloadStoreUri"];
 }
 
 enum WorkerCapability {


### PR DESCRIPTION
## What

Adds a single new field to `GetWorkItemsRequest` in `protos/orchestrator_service.proto`:

```proto
string external_payload_store_uri = 12 [json_name = "externalPayloadStoreUri"];
```

Field number `12` was the next free number in the message (existing fields: `1`, `2`, `3`, `10`, `11`).

## Why

DTS externalizes large orchestration payloads to the customer's Azure Blob Storage, persisting only a `blob:v1:<container>:<blobName>` token (which does **not** include the storage account) in the database. To let the DTS dashboard display these payloads, the dashboard reads each blob directly from Azure Storage using the signed-in user's own AAD token — so DTS never touches the bytes or holds credentials.

For that to work, the backend needs the non-secret storage **account base URI**. The worker (which has the account configured) reports it to the backend on the existing large-payload capability handshake (the `GetWorkItems` request). This PR adds **only** that proto contract field.

The value is a non-secret base URI such as `https://<account>.blob.core.windows.net/`. It is empty when the worker has no external payload store configured and never contains a secret, SAS, or account key. The `json_name` keeps the JSON field name camelCase (`externalPayloadStoreUri`), consistent with neighboring fields.

## Scope

- Proto contract change only. This repo checks in no generated stubs and has no protoc build, so nothing is regenerated.
- No other message, service, RPC, or field is modified. `backend_service.proto` and the auto-purge messages are untouched.
- The dashboard-facing query response field lives in a DTS-owned proto in a different repo and is **not** part of this PR.

Kept as a **draft**.
